### PR TITLE
Fix typo in the AWARD_FOR button of the rightclick menu

### DIFF
--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -1179,7 +1179,7 @@ do
 					info.text = v.text
 					info.notCheckable = true
 					info.func = function()
-						LibDialog:Spawn("RCLOOTCOUNCIL_CONFIRM_AWARD", RCVotingFrame:GetAwardPopupData(session, name, data, v))
+						LibDialog:Spawn("RCLOOTCOUNCIL_CONFIRM_AWARD", RCVotingFrame:GetAwardPopupData(session, candidateName, data, v))
 					end
 					Lib_UIDropDownMenu_AddButton(info, level)
 				end


### PR DESCRIPTION
This typo is making AWARD_FOR button unusable, or award to the wrong person, or award to not existing person, because it is accessing the global variable ```name```.