### PR TITLE
Fix item type display in the voting Frame, especially for non-English Client

### DIFF
--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -376,7 +376,10 @@ function RCVotingFrame:SwitchSession(s)
 	elseif t.subType ~= "Miscellaneous" and t.subType ~= "Junk" then
 		if "Artifact Relic" == addon.db.global.localizedSubTypes[t.subType] then
 			local id = addon:GetItemIDFromLink(t.link)
-         self.frame.itemType:SetText((t.relic or select(3, C_ArtifactUI.GetRelicInfoByItemID(id))) or "".." "..t.subType or "")
+			local relicType = t.relic or select(3, C_ArtifactUI.GetRelicInfoByItemID(id)) or ""
+			local localizedRelicType = _G["RELIC_SLOT_TYPE_" .. relicType:upper()] or ""
+			local relicTooltipName = string.format(RELIC_TOOLTIP_TYPE, localizedRelicType)
+            self.frame.itemType:SetText(relicTooltipName)
 		else
 			self.frame.itemType:SetText(tostring(t.subType))
 		end

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -372,25 +372,7 @@ function RCVotingFrame:SwitchSession(s)
 	self.frame.itemLvl:SetText(format(L["ilvl: x"], t.ilvl))
 	-- Set a proper item type text
 
-	local nonLocalizedSubType = addon.db.global.localizedSubTypes[t.subType]
-
-	if RCTokenTable[addon:GetItemIDFromLink(t.link)] then -- It's a token
-		self.frame.itemType:SetText(L["Armor Token"])
-	elseif "Artifact Relic" == nonLocalizedSubType then
-		local id = addon:GetItemIDFromLink(t.link)
-		local relicType = t.relic or select(3, C_ArtifactUI.GetRelicInfoByItemID(id)) or ""
-		local localizedRelicType = _G["RELIC_SLOT_TYPE_" .. relicType:upper()] or ""
-		local relicTooltipName = string.format(RELIC_TOOLTIP_TYPE, localizedRelicType)
-        self.frame.itemType:SetText(relicTooltipName)
-    elseif t.equipLoc ~= "" then
-    	if nonLocalizedSubType and nonLocalizedSubType ~= "Miscellaneous" then
-			self.frame.itemType:SetText(getglobal(t.equipLoc)..", "..t.subType); -- getGlobal to translate from global constant to localized name
-		else
-			self.frame.itemType:SetText(getglobal(t.equipLoc))
-		end
-	else
-		self.frame.itemType:SetText(t.subType);
-	end
+	self.frame.itemType:SetText(addon:GetItemTypeText(t.link, t.subType, t.equipLoc, t.relic))
 
 	-- Update the session buttons
 	sessionButtons[s] = self:UpdateSessionButton(s, t.texture, t.link, t.awarded)

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -371,24 +371,25 @@ function RCVotingFrame:SwitchSession(s)
 	self.frame.iState:SetText(self:GetItemStatus(t.link))
 	self.frame.itemLvl:SetText(format(L["ilvl: x"], t.ilvl))
 	-- Set a proper item type text
-	if t.subType and t.subType ~= "Miscellaneous" and t.subType ~= "Junk" and t.equipLoc ~= "" then
-		self.frame.itemType:SetText(getglobal(t.equipLoc)..", "..t.subType); -- getGlobal to translate from global constant to localized name
-	elseif t.subType ~= "Miscellaneous" and t.subType ~= "Junk" then
-		if "Artifact Relic" == addon.db.global.localizedSubTypes[t.subType] then
-			local id = addon:GetItemIDFromLink(t.link)
-			local relicType = t.relic or select(3, C_ArtifactUI.GetRelicInfoByItemID(id)) or ""
-			local localizedRelicType = _G["RELIC_SLOT_TYPE_" .. relicType:upper()] or ""
-			local relicTooltipName = string.format(RELIC_TOOLTIP_TYPE, localizedRelicType)
-            self.frame.itemType:SetText(relicTooltipName)
+
+	local nonLocalizedSubType = addon.db.global.localizedSubTypes[t.subType]
+
+	if RCTokenTable[addon:GetItemIDFromLink(t.link)] then -- It's a token
+		self.frame.itemType:SetText(L["Armor Token"])
+	elseif "Artifact Relic" == nonLocalizedSubType then
+		local id = addon:GetItemIDFromLink(t.link)
+		local relicType = t.relic or select(3, C_ArtifactUI.GetRelicInfoByItemID(id)) or ""
+		local localizedRelicType = _G["RELIC_SLOT_TYPE_" .. relicType:upper()] or ""
+		local relicTooltipName = string.format(RELIC_TOOLTIP_TYPE, localizedRelicType)
+        self.frame.itemType:SetText(relicTooltipName)
+    elseif t.equipLoc ~= "" then
+    	if nonLocalizedSubType and nonLocalizedSubType ~= "Miscellaneous" then
+			self.frame.itemType:SetText(getglobal(t.equipLoc)..", "..t.subType); -- getGlobal to translate from global constant to localized name
 		else
-			self.frame.itemType:SetText(tostring(t.subType))
+			self.frame.itemType:SetText(getglobal(t.equipLoc))
 		end
 	else
-		if RCTokenTable[addon:GetItemIDFromLink(t.link)] then -- It's a token
-			self.frame.itemType:SetText(L["Armor Token"])
-		else
-			self.frame.itemType:SetText(getglobal(t.equipLoc));
-		end
+		self.frame.itemType:SetText(t.subType);
 	end
 
 	-- Update the session buttons

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -374,7 +374,7 @@ function RCVotingFrame:SwitchSession(s)
 	if t.subType and t.subType ~= "Miscellaneous" and t.subType ~= "Junk" and t.equipLoc ~= "" then
 		self.frame.itemType:SetText(getglobal(t.equipLoc)..", "..t.subType); -- getGlobal to translate from global constant to localized name
 	elseif t.subType ~= "Miscellaneous" and t.subType ~= "Junk" then
-		if t.subType == addon.db.global.localizedSubTypes["Artifact Relic"] then
+		if "Artifact Relic" == addon.db.global.localizedSubTypes[t.subType] then
 			local id = addon:GetItemIDFromLink(t.link)
          self.frame.itemType:SetText((t.relic or select(3, C_ArtifactUI.GetRelicInfoByItemID(id))) or "".." "..t.subType or "")
 		else

--- a/Utils/autopass.lua
+++ b/Utils/autopass.lua
@@ -75,7 +75,7 @@ local relics = {
 --@return true if the player should autopass the given item.
 function RCLootCouncil:AutoPassCheck(subType, equipLoc, link, isToken, isRelic)
 	if not tContains(autopassOverride, equipLoc) then
-		if isRelic or (equipLoc == "" and subType == self.db.global.localizedSubTypes["Artifact Relic"]) then
+		if isRelic or (equipLoc == "" and "Artifact Relic" == self.db.global.localizedSubTypes[subType]) then
 			if isRelic then -- New in v2.3+
 				self:DebugLog("NewRelicAutopassCheck", link, isRelic)
 				return not tContains(relics[self.playerClass], isRelic)

--- a/core.lua
+++ b/core.lua
@@ -1051,10 +1051,25 @@ local subTypeLookup = {
 	["Wands"]					= 128096, -- Demonspine Wand
 	["Warglaives"]				= 141604, -- Glaive of the Fallen
 	["Artifact Relic"]		= 141271, -- Hope of the Forest
+	["Miscellaneous"]       = 151961, -- Legionsteel Flywheel (Trinket)
 }
 
 function RCLootCouncil:LocalizeSubTypes()
-	if self.db.global.localizedSubTypes.created == GetLocale() then return end -- We only need to create it once, if game locale is the same as stored locale.
+	if self.db.global.localizedSubTypes.created == GetLocale() then
+		local cached = true
+		localizedSubTypesInverse = {}
+		for sType, name in pairs(self.db.global.localizedSubTypes) do
+			localizedSubTypesInverse[name] = sType
+		end
+		for name, _ in pairs(subTypeLookup) do
+			if not localizedSubTypesInverse[name] then
+				cached = false
+			end
+		end
+		if cached then 
+			return -- We only need to create it once, if game locale is the same as stored locale, and everything is cached.
+		end 
+	end
 	-- Get the item info
 	for _, item in pairs(subTypeLookup) do
 		GetItemInfo(item)
@@ -1067,8 +1082,8 @@ function RCLootCouncil:LocalizeSubTypes()
 			self:DebugLog("Found "..name.." localized as: "..sType)
 		else -- Probably not cached, set a timer
 			self:Debug("We didn't find:", name, item)
-			self:ScheduleTimer("Timer", 2, "LocalizeSubTypes")
 			self.db.global.localizedSubTypes.created = false
+			self:ScheduleTimer("Timer", 2, "LocalizeSubTypes")
 			return
 		end
 	end

--- a/core.lua
+++ b/core.lua
@@ -1932,6 +1932,28 @@ function RCLootCouncil:HideTooltip()
 	GameTooltip:Hide()
 end
 
+-- @return a text of the link explaining its type. For example, "Fel Artifact Relic", "Chest, Mail"
+function RCLootCouncil:GetItemTypeText(link, subType, equipLoc, relicType)
+	local nonLocalizedSubType = self.db.global.localizedSubTypes[subType]
+	if RCTokenTable[self:GetItemIDFromLink(link)] then -- It's a token
+		return L["Armor Token"]
+	elseif "Artifact Relic" == nonLocalizedSubType then
+		local id = self:GetItemIDFromLink(link)
+		relicType = relicType or select(3, C_ArtifactUI.GetRelicInfoByItemID(id)) or ""
+		local localizedRelicType = _G["RELIC_SLOT_TYPE_" .. relicType:upper()] or ""
+		local relicTooltipName = string.format(RELIC_TOOLTIP_TYPE, localizedRelicType)
+        return relicTooltipName
+    elseif equipLoc ~= "" and getglobal(equipLoc) then
+    	if subType and nonLocalizedSubType ~= "Miscellaneous" then
+			return getglobal(equipLoc)..", "..subType -- getGlobal to translate from global constant to localized name
+		else
+			return getglobal(equipLoc)
+		end
+	else
+		return subType or ""
+	end
+end
+
 --- Formats a name with or without realmName.
 -- @paramsig name
 -- @param name Name with(out) realmname.


### PR DESCRIPTION
Changelog:

+ Armor Token is no longer displayed as "Junk" for non-English client.
+ Relic type is now shown for non-English client.
   + Besides, relic is now shown as "xxx Artifact Relic" instead of "xxx" for English client.
+ Trinket is now shown as "Trinket" instead of "Trinket, "Miscellaneous" for non-English client

###### Dev
+ Code that calculates the text of item type is put into a separate function.
+ Fix a usage of ```addon.db.global.localizedSubTypes```
  + new:  ```"Artifact Relic" == self.db.global.localizedSubTypes[subType]```
  + old: ```subType == self.db.global.localizedSubTypes["Artifact Relic"]```
+ "Miscellaneous" is added to the subTypeLookup