### PR TITLE
Fix nil error on login caused by GetRaidRosterInfo(i) returns nil

### DIFF
--- a/ml_core.lua
+++ b/ml_core.lua
@@ -111,8 +111,9 @@ function RCLootCouncilML:UpdateGroup(ask)
 	for name in pairs(self.candidates) do	group_copy[name] = true end
 	for i = 1, GetNumGroupMembers() do
 		local name, _, _, _, _, class, _, _, _, _, _, role  = GetRaidRosterInfo(i)
-		name = addon:UnitName(name) -- Get their unambiguated name
+		
 		if name then -- Apparantly name can be nil (ticket #223)
+			name = addon:UnitName(name) -- Get their unambiguated name
 			if group_copy[name] then	-- If they're already registered
 				group_copy[name] = nil	-- remove them from the check
 			else -- add them
@@ -123,6 +124,9 @@ function RCLootCouncilML:UpdateGroup(ask)
 				self:AddCandidate(name, class, role) -- Add them in case they haven't installed the adoon
 				updates = true
 			end
+		else
+			addon:Debug("ML:UpdateGroup", "GetRaidRosterInfo returns nil. Abort and retry after 1s.")
+			return self:ScheduleTimer("UpdateGroup", 1, ask) -- Group info is not ready. Abort and retry.
 		end
 	end
 	-- If anything's left in group_copy it means they left the raid, so lets remove them


### PR DESCRIPTION
```RCLootCouncilML:UpdateGroup(ask)``` sometimes gives nil error on login.
This is due to ```GetRaidRosterInfo(i), 1<=i<=GetNumGroupMembers()``` can return nil when group information is not ready. We should abort and retry ```ML:UpdateGroup``` when we detect it.


Error Messages:
```
3x RCLootCouncil\core.lua:1605: bad argument #1 to 'gsub' (string expected, got nil)
[C]: in function `gsub'
RCLootCouncil\core.lua:1605: in function `UnitName'
RCLootCouncil\ml_core.lua:114: in function `UpdateGroup'
RCLootCouncil\ml_core.lua:279: in function `NewML'
RCLootCouncil\core.lua:1289: in function `NewMLCheck'
RCLootCouncil\core.lua:1223: in function `?'
...ack\Libs\CallbackHandler-1.0\CallbackHandler-1.0-6.lua:147: in function <...ack\Libs\CallbackHandler-1.0\CallbackHandler-1.0.lua:147>
[string "safecall Dispatcher[1]"]:4: in function <[string "safecall Dispatcher[1]"]:4>
[C]: ?
[string "safecall Dispatcher[1]"]:13: in function `?'
...ack\Libs\CallbackHandler-1.0\CallbackHandler-1.0-6.lua:92: in function `Fire'
...Ons\RCLootCouncil\Libs\AceEvent-3.0\AceEvent-3.0-4.lua:120: in function <...Ons\RCLootCouncil\Libs\AceEvent-3.0\AceEvent-3.0.lua:119>
```