### PR TITLE
Test announcement when solo

### DIFF
--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -1454,11 +1454,7 @@ function RCVotingFrame:StartManualRoll()
 		manualRollSession = session
 		wipe(manualRollResults)
 		self:RegisterEvent("CHAT_MSG_SYSTEM")
-		if IsInGroup() then
-			SendChatMessage(string.format(L["request_rolls_announcement"], lootTable[session].link), addon:GetAnnounceChannel("group"))
-		else -- Alone, just print it for clarity
-			addon:Print(string.format(L["request_rolls_announcement"], lootTable[session].link))
-		end
+		addon:SendAnnouncement(string.format(L["request_rolls_announcement"], lootTable[session].link), "group")
 	else
 		addon:Debug("Start manual roll by non-ML?")
 	end

--- a/core.lua
+++ b/core.lua
@@ -590,7 +590,9 @@ end
 -- Send the msg to the channel if it is valid. Otherwise just print the messsage.
 function RCLootCouncil:SendAnnouncement(msg, channel)
 	if channel == "NONE" then return end
-
+	if self.testMode then
+		msg = "("..L["Test"]..") "..msg
+	end
 	if not IsInGroup() and (channel == "group" or channel == "RAID" or channel == "PARTY" or channel == "INSTANCE_CHAT") then
 		self:Print(msg)
 	elseif not IsInGuild() and (channel == "GUILD" or channel == "OFFICER") then

--- a/core.lua
+++ b/core.lua
@@ -587,6 +587,19 @@ function RCLootCouncil:ChatCommand(msg)
 	end
 end
 
+-- Send the msg to the channel if it is valid. Otherwise just print the messsage.
+function RCLootCouncil:SendAnnouncement(msg, channel)
+	if channel == "NONE" then return end
+
+	if not IsInGroup() and (channel == "group" or channel == "RAID" or channel == "PARTY" or channel == "INSTANCE_CHAT") then
+		self:Print(msg)
+	elseif not IsInGuild() and (channel == "GUILD" or channel == "OFFICER") then
+		self:Print(msg)
+	else
+		SendChatMessage(msg, self:GetAnnounceChannel(channel))
+	end
+end
+
 --- Send a RCLootCouncil Comm Message using AceComm-3.0
 -- See RCLootCouncil:OnCommReceived() on how to receive these messages.
 -- @param target The receiver of the message. Can be "group", "guild" or "playerName".

--- a/core.lua
+++ b/core.lua
@@ -248,7 +248,7 @@ function RCLootCouncil:OnInitialize()
 			announceItems = false,
 			announceText = L["Items under consideration:"],
 			announceChannel = "group",
-			announceItemString = "&s: &i", -- The message posted for each item, default: "session: itemlink"
+			announceItemString = "&s: &i (&l, &t)", -- The message posted for each item, default: "session: itemlink (ilvl, type)"
 
 			responses = self.responses,
 

--- a/ml_core.lua
+++ b/ml_core.lua
@@ -521,6 +521,8 @@ function RCLootCouncilML:Award(session, winner, response, reason)
 			addon:SendCommand("group", "awarded", session, winner)
 			addon:Print(format(L["The item would now be awarded to 'player'"], addon.Ambiguate(winner)))
 			self.lootTable[session].awarded = winner
+			self:AnnounceAward(winner, self.lootTable[session].link,
+			 reason and reason.text or response, addon:GetActiveModule("votingframe"):GetCandidateData(session, winner, "roll"), session)
 			if self:HasAllItemsBeenAwarded() then
 				 addon:Print(L["All items has been awarded and  the loot session concluded"])
 			end

--- a/ml_core.lua
+++ b/ml_core.lua
@@ -625,13 +625,13 @@ RCLootCouncilML.announceItemStringsDesc = {
 function RCLootCouncilML:AnnounceItems()
 	if not db.announceItems then return end
 	addon:DebugLog("ML:AnnounceItems()")
-	SendChatMessage(db.announceText, addon:GetAnnounceChannel(db.announceChannel))
+	addon:SendAnnouncement(db.announceText, db.announceChannel)
 	for k,v in ipairs(self.lootTable) do
 		local msg = db.announceItemString
 		for text, func in pairs(self.announceItemStrings) do
 			msg = gsub(msg, text, tostring(func(k, v.link, v)))
 		end
-		SendChatMessage(msg, addon:GetAnnounceChannel(db.announceChannel))
+		addon:SendAnnouncement(msg, db.announceChannel)
 	end
 end
 
@@ -672,12 +672,10 @@ function RCLootCouncilML:AnnounceAward(name, link, response, roll, session)
 	if db.announceAward then
 		for k,v in pairs(db.awardText) do
 			local message = v.text
-			if v.channel ~= "NONE" then
-				for text, func in pairs(self.awardStrings) do
-					message = gsub(message, text, tostring(func(name, link, response, roll, session)))
-				end
-				SendChatMessage(message, addon:GetAnnounceChannel(v.channel))
+			for text, func in pairs(self.awardStrings) do
+				message = gsub(message, text, tostring(func(name, link, response, roll, session)))
 			end
+			addon:SendAnnouncement(message, v.channel)
 		end
 	end
 end


### PR DESCRIPTION
+ all announcement print itself when the channel is invalid. (channel is "group" when not in group. channel is "guild" when not in guild).
+ While in test mode, all announcement is prefixed by "(Test)" to avoid confusion by other people.
+ Also send award message while in test mode.
+ New API: RC:SendAnnouncement(msg, channel)