### PR TITLE
The ilvl of armor token is shown as ###+ instead of ###

### DIFF
--- a/Modules/lootFrame.lua
+++ b/Modules/lootFrame.lua
@@ -146,7 +146,7 @@ do
 			entry.itemText:SetText(entry.item.link or "error")
 			entry.icon:SetNormalTexture(entry.item.texture or "Interface\\InventoryItems\\WoWUnknownItem01")
 			local typeText = addon:GetItemTypeText(item.link, item.subType, item.equipLoc, item.isTier, item.isRelic)
-			entry.itemLvl:SetText((entry.item.ilvl or 0).."  |cff7fffff"..typeText.."|r")
+			entry.itemLvl:SetText(addon:GetItemLevelText(entry.item.ilvl, entry.item.isTier).."  |cff7fffff"..typeText.."|r")
 			if addon.mldb.timeout then
 				entry.timeoutBar:SetMinMaxValues(0, addon.mldb.timeout or addon.db.profile.timeout)
 				entry.timeoutBar:Show()

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -409,7 +409,7 @@ function RCVotingFrame:SwitchSession(s)
 	self.frame.itemIcon:SetNormalTexture(t.texture)
 	self.frame.itemText:SetText(t.link)
 	self.frame.iState:SetText(self:GetItemStatus(t.link))
-	self.frame.itemLvl:SetText(format(_G.ITEM_LEVEL_ABBR..": %d", t.ilvl))
+	self.frame.itemLvl:SetText(_G.ITEM_LEVEL_ABBR..": "..addon:GetItemLevelText(t.ilvl, t.token))
 	-- Set a proper item type text
 
 	self.frame.itemType:SetText(addon:GetItemTypeText(t.link, t.subType, t.equipLoc, t.token, t.relic))

--- a/core.lua
+++ b/core.lua
@@ -2060,6 +2060,15 @@ function RCLootCouncil:HideTooltip()
 	GameTooltip:Hide()
 end
 
+function RCLootCouncil:GetItemLevelText(ilvl, token)
+	if not ilvl then ilvl = 0 end
+	if token then
+		return ilvl.."+"
+	else
+		return ilvl
+	end
+end
+
 -- @return a text of the link explaining its type. For example, "Fel Artifact Relic", "Chest, Mail"
 function RCLootCouncil:GetItemTypeText(link, subType, equipLoc, tokenSlot, relicType)
 	local englishSubType = self.db.global.localizedSubTypes[subType]

--- a/ml_core.lua
+++ b/ml_core.lua
@@ -611,7 +611,7 @@ end
 RCLootCouncilML.announceItemStrings = {
 	["&s"] = function(ses) return ses end,
 	["&i"] = function(...) return select(2,...) end,
-	["&l"] = function(_, _, v) return v.ilvl or "" end,
+	["&l"] = function(_, _, v) return addon:GetItemLevelText(v.ilvl, v.token) end,
 	["&t"] = function(_, _, t) return addon:GetItemTypeText(t.link, t.subType, t.equipLoc, t.token, t.relic) end,
 }
 -- The description for each keyword
@@ -643,7 +643,8 @@ RCLootCouncilML.awardStrings = {
 	["&i"] = function(...) return select(2, ...) end,
 	["&r"] = function(...) return select(3, ...) end,
 	["&n"] = function(...) return select(4, ...) or "" end,
-	["&l"] = function(...) return RCLootCouncilML.lootTable[select(5, ...)].ilvl or "" end,
+	["&l"] = function(...) local t = RCLootCouncilML.lootTable[select(5, ...)]
+							return addon:GetItemLevelText(t.ilvl, t.token) end,
 	["&t"] = function(...)
 		local t = RCLootCouncilML.lootTable[select(5,...)]
 		return addon:GetItemTypeText(t.link, t.subType, t.equipLoc, t.token, t.relic)


### PR DESCRIPTION
+ The ilvl of armor token is shown as ###+ instead of ###
  + This change has been applied to voting frame, loot frame, award announcement and consideration announcement.