### PR TITLE
VotingFrame:Update() should check if loot table exists.

### DIFF
--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -364,7 +364,7 @@ end
 
 function RCVotingFrame:Update()
 	if not self.frame then return end -- No updates when it doesn't exist
-	if not lootTable[session] then return end -- No updates if lootTable doesn't exists.
+	if not lootTable[session] then return end -- No updates if lootTable doesn't exist.
 	self.frame.st:SortData()
 	-- update awardString
 	if lootTable[session] and lootTable[session].awarded then

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -364,6 +364,7 @@ end
 
 function RCVotingFrame:Update()
 	if not self.frame then return end -- No updates when it doesn't exist
+	if not lootTable[session] then return end -- No updates if lootTable doesn't exists.
 	self.frame.st:SortData()
 	-- update awardString
 	if lootTable[session] and lootTable[session].awarded then


### PR DESCRIPTION
#### error message
```
122x RCLootCouncil\Modules\votingFrame.lua:342: attempt to index field '?' (a nil value)
RCLootCouncil\Modules\votingFrame.lua:342: in function <RCLootCouncil\Modules\votingFrame.lua:338>
RCLootCouncil\Modules\votingFrame.lua:397: in function `Update'
RCLootCouncil\Modules\votingFrame.lua:173: in function `?'
...ack\Libs\CallbackHandler-1.0\CallbackHandler-1.0-6.lua:147: in function <...ack\Libs\CallbackHandler-1.0\CallbackHandler-1.0.lua:147>
[string "safecall Dispatcher[4]"]:4: in function <[string "safecall Dispatcher[4]"]:4>
[C]: ?
[string "safecall Dispatcher[4]"]:13: in function `?'
...ack\Libs\CallbackHandler-1.0\CallbackHandler-1.0-6.lua:92: in function `Fire'
...faceBugSack\Libs\AceComm-3.0\AceComm-3.0-10.lua:260: in function <...faceBugSack\Libs\AceComm-3.0\AceComm-3.0.lua:242>

Locals:
nil
```