### PR TITLE
Fix bug when ML loots corpse immediately after reload.

### DIFF
--- a/ml_core.lua
+++ b/ml_core.lua
@@ -367,6 +367,10 @@ function RCLootCouncilML:OnEvent(event, ...)
 	if event == "LOOT_OPENED" then -- IDEA Check if event LOOT_READY is useful here (also check GetLootInfo() for this)
 		self.lootOpen = true
 		if not InCombatLockdown() then
+			if not addon.candidates[addon.playerName] or #addon.council == 0 then
+				addon:Print(L["Please wait a few seconds until all data has been synchronized."])
+				return addon:Debug("Data wasn't ready on loot open", addon.candidates[addon.playerName], #addon.council)
+			end
 			self:LootOpened()
 		else
 			addon:Print(L["You can't start a loot session while in combat."])

--- a/ml_core.lua
+++ b/ml_core.lua
@@ -406,7 +406,7 @@ function RCLootCouncilML:LootOpened()
 			end
 		end
 		if #self.lootTable > 0 and not self.running then
-			if db.autoStart then -- Settings say go
+			if db.autoStart and addon.candidates[addon.playerName] and #addon.council > 0 then -- Auto start only if data is ready
 				self:StartSession()
 			else
 				addon:CallModule("sessionframe")

--- a/ml_core.lua
+++ b/ml_core.lua
@@ -367,10 +367,6 @@ function RCLootCouncilML:OnEvent(event, ...)
 	if event == "LOOT_OPENED" then -- IDEA Check if event LOOT_READY is useful here (also check GetLootInfo() for this)
 		self.lootOpen = true
 		if not InCombatLockdown() then
-			if not addon.candidates[addon.playerName] or #addon.council == 0 then
-				addon:Print(L["Please wait a few seconds until all data has been synchronized."])
-				return addon:Debug("Data wasn't ready on loot open", addon.candidates[addon.playerName], #addon.council)
-			end
 			self:LootOpened()
 		else
 			addon:Print(L["You can't start a loot session while in combat."])


### PR DESCRIPTION
+ If ML autoStart the session, when ML loots corpse immediately after reload, because data isn't ready, session does not start, but item has been added to the lootTable. If ML closes and reopens the loot window, items in the corpse will be added multiple times to the lootTable.
+ We solve this problem by showing session frame instead of autoStart if data isn't ready.