### PR TITLE
Send ml candidates

### DIFF
--- a/Locale/enUS.lua
+++ b/Locale/enUS.lua
@@ -203,6 +203,7 @@ L["ignore_input_desc"] = "Enter an itemID to add to the ignore list causing RCLo
 L["ignore_input_usage"] = "This function only accepts itemIDs (number)"
 L["ignore_list_desc"] = "Items RCLootCouncil is ignoring. Click on a item to remove it."
 L["ignore_options_desc"] = "Control which items RCLootCouncil should ignore. If you add an item that isn't cached, you need switch to another tab and back before you'll see it in the list."
+L["Ineligible"] = true
 L["Item received and added from 'player'"] = "Item received and added from %s."
 L["Item was awarded to"] = true
 L["Item"] = true

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -1355,7 +1355,7 @@ do
 			end
 
 			-- Build the data table:
-			local data = {["STATUS"] = true, ["PASS"] = true, ["AUTOPASS"] = true, ["INELIGIBLE"] = true, tier = {}, relic = {}}
+			local data = {tier = {}, relic = {}}
 
 			local isTier, isRelic
 			-- If we're viewing a tier token and the ML have it enabled, we want to see it
@@ -1437,8 +1437,7 @@ do
 					Lib_UIDropDownMenu_AddButton(info, level)
 				end
 			end
-			for k in pairs(data) do -- A bit redundency, but it makes sure these "specials" comes last
-				if type(k) == "string" and k ~= "tier" and k ~= "relic" then
+			for _, k in ipairs({"STATUS", "PASS", "AUTOPASS", "INELIGIBLE"}) do
 					if k == "STATUS" then
 						info.text = L["Status texts"]
 						info.colorCode = "|cffde34e2" -- purpleish
@@ -1453,7 +1452,6 @@ do
 					end
 					info.checked = db.modules["RCVotingFrame"].filters[k]
 					Lib_UIDropDownMenu_AddButton(info, level)
-				end
 			end
 		end
 	end

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -988,7 +988,7 @@ function RCVotingFrame.filterFunc(table, row)
 		end
 	end
 
-	if response == "AUTOPASS" or response == "PASS" or type(response) == "number" then
+	if response == "AUTOPASS" or response == "PASS" or response == "INELIGIBLE" or type(response) == "number" then
 		if lootTable[session].token and addon.mldb.tierButtonsEnabled and type(response) == "number"then
 			return db.modules["RCVotingFrame"].filters.tier[response]
 		elseif lootTable[session].relic and addon.mldb.relicButtonsEnabled and type(response) == "number" then
@@ -1355,7 +1355,7 @@ do
 			end
 
 			-- Build the data table:
-			local data = {["STATUS"] = true, ["PASS"] = true, ["AUTOPASS"] = true, tier = {}, relic = {}}
+			local data = {["STATUS"] = true, ["PASS"] = true, ["AUTOPASS"] = true, ["INELIGIBLE"] = true, tier = {}, relic = {}}
 
 			local isTier, isRelic
 			-- If we're viewing a tier token and the ML have it enabled, we want to see it

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -96,9 +96,9 @@ function RCVotingFrame:Show()
 	end
 end
 
-function RCVotingFrame:ReceiveLootTable(lootTable, mlCandidates)
+function RCVotingFrame:ReceiveLootTable(lootTable)
 	active = true
-	self:Setup(lootTable, mlCandidates)
+	self:Setup(lootTable)
 	if not addon.enabled then return end -- We just want things ready
 	if db.autoOpen then
 		self:Show()
@@ -271,10 +271,9 @@ function RCVotingFrame:GetCurrentSession()
 	return session
 end
 
-function RCVotingFrame:Setup(table, mlTable)
+function RCVotingFrame:Setup(table)
 	--lootTable[session] = {bagged, lootSlot, awarded, name, link, quality, ilvl, type, subType, equipLoc, texture, boe}
 	lootTable = table -- Extract all the data we get
-	lootTable.mlCandidates = mlTable
 	for session, t in ipairs(lootTable) do -- and build the rest (candidates)
 		lootTable[session].haveVoted = false -- Have we voted for ANY candidate in this session?
 		t.candidates = {}
@@ -299,7 +298,6 @@ function RCVotingFrame:Setup(table, mlTable)
 				t.candidates[name].response = "INELIGIBLE"
 			end
 		end
-
 		-- Init session toggle
 		sessionButtons[session] = self:UpdateSessionButton(session, t.texture, t.link, t.awarded)
 		sessionButtons[session]:Show()

--- a/core.lua
+++ b/core.lua
@@ -68,7 +68,6 @@ local frames = {} -- Contains all frames created by RCLootCouncil:CreateFrame()
 local unregisterGuildEvent = false
 local player_relogged = true -- Determines if we potentially need data from the ML due to /rl
 local lootTable = {}
-local mlCandidates = nil -- candidates that eligible to receive loot from ML
 
 local IsPartyLFG = IsPartyLFG
 
@@ -664,7 +663,7 @@ function RCLootCouncil:OnCommReceived(prefix, serializedMsg, distri, sender)
 		if test then
 			if command == "lootTable" then
 				if self:UnitIsUnit(sender, self.masterLooter) then
-					lootTable, mlCandidates = unpack(data)
+					lootTable = unpack(data)
 					-- Send "DISABLED" response when not enabled
 					if not self.enabled then
 						for i = 1, #lootTable do
@@ -695,7 +694,7 @@ function RCLootCouncil:OnCommReceived(prefix, serializedMsg, distri, sender)
 
 					-- Hand the lootTable to the votingFrame
 					if self.isCouncil or self.mldb.observe then
-						self:GetActiveModule("votingframe"):ReceiveLootTable(lootTable, mlCandidates)
+						self:GetActiveModule("votingframe"):ReceiveLootTable(lootTable)
 					end
 
 					self:SendCommand("group", "lootAck", self.playerName) -- send ack
@@ -704,7 +703,7 @@ function RCLootCouncil:OnCommReceived(prefix, serializedMsg, distri, sender)
 					-- The actual response/note are left unsent if not autopassed.
 					for ses, v in ipairs(lootTable) do
 						local response = nil
-						if v.lootSlot and not v.bagged and mlCandidates and not mlCandidates[self.playerName] then -- Ineligible for the loot
+						if v.lootSlot and not v.bagged and lootTable.mlCandidates and not lootTable.mlCandidates[self.playerName] then -- Ineligible for the loot
 							lootTable[ses].autopass = true
 						elseif db.autoPass then
 							if (v.boe and db.autoPassBoE) or not v.boe then

--- a/core.lua
+++ b/core.lua
@@ -704,7 +704,9 @@ function RCLootCouncil:OnCommReceived(prefix, serializedMsg, distri, sender)
 					-- The actual response/note are left unsent if not autopassed.
 					for ses, v in ipairs(lootTable) do
 						local response = nil
-						if db.autoPass then
+						if v.lootSlot and not v.bagged and mlCandidates and not mlCandidates[self.playerName] then -- Ineligible for the loot
+							lootTable[ses].autopass = true
+						elseif db.autoPass then
 							if (v.boe and db.autoPassBoE) or not v.boe then
 								if self:AutoPassCheck(v.subType, v.equipLoc, v.link, v.token, v.relic) then
 									self:Debug("Autopassed on: ", v.link)

--- a/core.lua
+++ b/core.lua
@@ -68,6 +68,7 @@ local frames = {} -- Contains all frames created by RCLootCouncil:CreateFrame()
 local unregisterGuildEvent = false
 local player_relogged = true -- Determines if we potentially need data from the ML due to /rl
 local lootTable = {}
+local mlCandidates = nil -- candidates that eligible to receive loot from ML
 
 local IsPartyLFG = IsPartyLFG
 
@@ -108,6 +109,7 @@ function RCLootCouncil:OnInitialize()
 		NOTHING			= { color = {0.5,0.5,0.5,1},		sort = 505,		text = L["Offline or RCLootCouncil not installed"], },
 		PASS				= { color = {0.7, 0.7,0.7,1},		sort = 800,		text = _G.PASS,},
 		AUTOPASS			= { color = {0.7,0.7,0.7,1},		sort = 801,		text = L["Autopass"], },
+		INELIGIBLE 			= { color = {0.7,0.7,0.7,1},		sort = 801,		text = L["Ineligible"], },
 		DISABLED			= { color = {0.3,0.35,0.5,1},		sort = 802,		text = L["Candidate has disabled RCLootCouncil"], },
 		NOTINRAID		= { color = {0.7,0.6,0,1}, 		sort = 803, 	text = L["Candidate is not in the instance"]},
 		--[[1]]			  { color = {0,1,0,1},				sort = 1,		text = L["Mainspec/Need"],},
@@ -662,7 +664,7 @@ function RCLootCouncil:OnCommReceived(prefix, serializedMsg, distri, sender)
 		if test then
 			if command == "lootTable" then
 				if self:UnitIsUnit(sender, self.masterLooter) then
-					lootTable = unpack(data)
+					lootTable, mlCandidates = unpack(data)
 					-- Send "DISABLED" response when not enabled
 					if not self.enabled then
 						for i = 1, #lootTable do
@@ -693,7 +695,7 @@ function RCLootCouncil:OnCommReceived(prefix, serializedMsg, distri, sender)
 
 					-- Hand the lootTable to the votingFrame
 					if self.isCouncil or self.mldb.observe then
-						self:GetActiveModule("votingframe"):ReceiveLootTable(lootTable)
+						self:GetActiveModule("votingframe"):ReceiveLootTable(lootTable, mlCandidates)
 					end
 
 					self:SendCommand("group", "lootAck", self.playerName) -- send ack

--- a/core.lua
+++ b/core.lua
@@ -108,12 +108,12 @@ function RCLootCouncil:OnInitialize()
 		NOTHING			= { color = {0.5,0.5,0.5,1},		sort = 505,		text = L["Offline or RCLootCouncil not installed"], },
 		PASS				= { color = {0.7, 0.7,0.7,1},		sort = 800,		text = _G.PASS,},
 		AUTOPASS			= { color = {0.7,0.7,0.7,1},		sort = 801,		text = L["Autopass"], },
-		INELIGIBLE 			= { color = {0.7,0.7,0.7,1},		sort = 801,		text = L["Ineligible"], },
 		DISABLED			= { color = {0.3,0.35,0.5,1},		sort = 802,		text = L["Candidate has disabled RCLootCouncil"], },
 		NOTINRAID		= { color = {0.7,0.6,0,1}, 		sort = 803, 	text = L["Candidate is not in the instance"]},
 		--[[1]]			  { color = {0,1,0,1},				sort = 1,		text = L["Mainspec/Need"],},
 		--[[2]]			  { color = {1,0.5,0,1},			sort = 2,		text = L["Offspec/Greed"],	},
 		--[[3]]			  { color = {0,0.7,0.7,1},			sort = 3,		text = L["Minor Upgrade"],},
+		INELIGIBLE 			= { color = {0.7,0.7,0.7,1},		sort = 804,		text = L["Ineligible"], },
 		tier = {
 			--[[1]]		  { color = {0.1,1,0.5,1},			sort = 1,		text = L["4th Tier Piece"],},
 			--[[2]]		  { color = {1,1,0.5,1},			sort = 2,		text = L["2nd Tier Piece"],},

--- a/ml_core.lua
+++ b/ml_core.lua
@@ -30,7 +30,6 @@ end
 function RCLootCouncilML:OnEnable()
 	db = addon:Getdb()
 	self.candidates = {} 	-- candidateName = { class, role, rank }
-	self.mlCandidates = {}  -- candidateName = true, the list of candidates who are eligible to receive loot.
 	self.lootTable = {} 		-- The MLs operating lootTable, see ML:AddItem()
 	self.awardedInBags = {} -- Awarded items that are stored in MLs inventory
 									-- i = { link, winner }
@@ -169,7 +168,7 @@ function RCLootCouncilML:StartSession()
 	end
 	self.running = true
 
-	addon:SendCommand("group", "lootTable", self.lootTable, self.mlCandidates)
+	addon:SendCommand("group", "lootTable", self.lootTable)
 
 	self:AnnounceItems()
 	-- Start a timer to set response as offline/not installed unless we receive an ack
@@ -424,7 +423,7 @@ function RCLootCouncilML:LootOpened()
 			end
 		end
 
-		self.mlCandidates = self:BuildMLCandidates()
+		self.lootTable.mlCandidates = self:BuildMLCandidates()
 
 		if #self.lootTable > 0 and not self.running then
 			if db.autoStart then -- Settings say go


### PR DESCRIPTION
+ ML sends master looter candidates (```lootTable.mlCandidates```) with lootTable
+ If a candidate is not on MLcandidate list if the item is master looted, set response as "INELIGIBLE"
+ If the a candidate's response is "INELIGIBLE", its response will always be "ineligible" and cant be changed.
+ backward compatility does not break because we check if ```mlCandidates``` is received.
+ This has been tested by master looting inside a low level dungeon.
---

### Pros
+ "Ineligible" is better information than "not in raid", "offline/RC not installed", "not response in time",

#### Cons 
+ lootTable is bigger, but not too much. For the extreme edge case, 30man in the raid, everyone has 12 letters name and longest realm name, mlCandidates cost 1000 bytes to serialize. ( about the size of lootTable with 4 items, which takes about 1s to transmit) But considering time take in loot session for a big raid, this time does not matter.