### PR TITLE
Fix bug when response contains special characters.

### DIFF
--- a/ml_core.lua
+++ b/ml_core.lua
@@ -622,7 +622,8 @@ function RCLootCouncilML:AnnounceItems()
 	for k,v in ipairs(self.lootTable) do
 		local msg = db.announceItemString
 		for text, func in pairs(self.announceItemStrings) do
-			msg = gsub(msg, text, tostring(func(k, v.link, v)))
+			-- escapePatternSymbols is defined in FrameXML/ChatFrame.lua that escapes special characters.
+			msg = gsub(msg, text, escapePatternSymbols(tostring(func(k, v.link, v))))
 		end
 		addon:SendAnnouncement(msg, db.announceChannel)
 	end
@@ -667,7 +668,8 @@ function RCLootCouncilML:AnnounceAward(name, link, response, roll, session)
 		for k,v in pairs(db.awardText) do
 			local message = v.text
 			for text, func in pairs(self.awardStrings) do
-				message = gsub(message, text, tostring(func(name, link, response, roll, session)))
+				-- escapePatternSymbols is defined in FrameXML/ChatFrame.lua that escapes special characters.
+				message = gsub(message, text, escapePatternSymbols(tostring(func(name, link, response, roll, session))))
 			end
 			addon:SendAnnouncement(message, v.channel)
 		end


### PR DESCRIPTION
#### Changelog
+ Fix a problem in announcement when response contains special characters such as %, [], ()

---
+ A lua function defined by FrameXML/ChatFrame.lua is used to fix this problem. Copy and paste here for reference.
```
local symbols = {"%%", "%*", "%+", "%-", "%?", "%(", "%)", "%[", "%]", "%$", "%^"} --% has to be escaped first or everything is ruined
local replacements = {"%%%%", "%%%*", "%%%+", "%%%-", "%%%?", "%%%(", "%%%)", "%%%[", "%%%]", "%%%$", "%%%^"}
function escapePatternSymbols(text)
	for i=1, #symbols do
		text = text:gsub(symbols[i], replacements[i])
	end
	return text
end
```
