### PR TITLE
Fix bug that RCHistory deletes unintended entry.

### DIFF
--- a/Modules/lootHistory.lua
+++ b/Modules/lootHistory.lua
@@ -252,6 +252,15 @@ function LootHistory.SetCellDelete(rowFrame, frame, data, cols, row, realrow, co
 			addon:Debug("Deleting:", name, lootDB[name][num].lootWon)
 			tremove(lootDB[name], num)
 			tremove(data, realrow)
+
+			for _, v in pairs(data) do -- Update data[realrow].num for other rows, they are CHANGED !!!
+				if v.name == name then
+					if v.num >= num then
+						v.num = v.num - 1
+					end
+				end
+			end
+
 			table:SortData()
 			if #lootDB[name] == 0 then -- last entry deleted
 				addon:DebugLog("Last Entry deleted, deleting name: ", name)


### PR DESCRIPTION
+ Fix a long standing bug that if we delete multiple entries of the same person without closing the history window, unintended entry is deleted.
+ How to reproduce:
  + Delete the earliest entry of player A.
  + Delete the latest entry of player A will cause an nil error.
  + Delete other entries of player A does not cause error and looks like the entry is deleted. However, close RC history window and reopen it shows wrong entry is deleted.
+ The reason of this bug is ```data[realrow].num``` is not updated when an entry is deleted.