### PR TITLE
Security enchancement: only send response and vote to council

### DIFF
--- a/Modules/lootFrame.lua
+++ b/Modules/lootFrame.lua
@@ -120,7 +120,7 @@ function LootFrame:OnRoll(entry, button)
 	-- Only send minimum neccessary data, because the information of current equipped gear has been sent when we receive the loot table.
 	-- target, session, link, ilvl, response, equipLoc, note, subType, relicType, isTier, isRelic, sendAvgIlvl, sendSpecID
 	for _, session in ipairs(item.sessions) do
-		addon:SendResponse("group", session, nil, nil, button, nil, item.note, nil, nil, isTier, isRelic, nil, nil)
+		addon:SendResponse("council", session, nil, nil, button, nil, item.note, nil, nil, isTier, isRelic, nil, nil)
 	end
 
 	if addon:Getdb().printResponse then

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -912,7 +912,7 @@ function RCVotingFrame.SetCellVote(rowFrame, frame, data, cols, row, realrow, co
 		frame.voteBtn:SetScript("OnClick", function(btn)
 			addon:Debug("Vote button pressed")
 			if lootTable[session].candidates[name].haveVoted then -- unvote
-				addon:SendCommand("group", "vote", session, name, -1)
+				addon:SendCommand("council", "vote", session, name, -1)
 				lootTable[session].candidates[name].haveVoted = false
 
 				-- Check if that was our only vote
@@ -934,7 +934,7 @@ function RCVotingFrame.SetCellVote(rowFrame, frame, data, cols, row, realrow, co
 					end
 				end
 				-- Do the vote
-				addon:SendCommand("group", "vote", session, name, 1)
+				addon:SendCommand("council", "vote", session, name, 1)
 				lootTable[session].candidates[name].haveVoted = true
 				lootTable[session].haveVoted = true
 			end

--- a/core.lua
+++ b/core.lua
@@ -621,14 +621,23 @@ function RCLootCouncil:SendCommand(target, command, ...)
 									-- Only send data to council, for security.
 		if self.mldb.observe or #self.council >= GetNumGroupMembers() then -- Everyone can see the voting frame, just send to the entire group
 			self:SendCommand("group", command, ...)
-		elseif not tContains(self.council, self.masterLooter) then -- council is invalid because it does not contain ML, just send to the entire group so we don't break stuffs.
-			self:Debug("SendCommand to council, but council does not contain ML", self.masterLooter)
-			self:SendCommand("group", command, ...)
 		else
-			self:SendCommand(self.masterLooter, command, ...) -- Send to ML first
+			local mlInCouncil = false
 			for _, v in ipairs(self.council) do
-				if v ~= self.masterLooter then -- Then other councilmen
-					self:SendCommand(v, command, ...)
+				if self:UnitIsUnit(v, self.masterLooter) then
+					mlInCouncil = true
+					break
+				end
+			end
+			if not mlInCouncil then -- council is invalid because it does not contain ML, just send to the entire group so we don't break stuffs.
+				self:Debug("SendCommand to council, but council does not contain ML", self.masterLooter)
+				self:SendCommand("group", command, ...)
+			else
+				self:SendCommand(self.masterLooter, command, ...) -- Send to ML first
+				for _, v in ipairs(self.council) do
+					if not self:UnitIsUnit(v, self.masterLooter) then -- Then other councilmen
+						self:SendCommand(v, command, ...)
+					end
 				end
 			end
 		end

--- a/core.lua
+++ b/core.lua
@@ -617,6 +617,21 @@ function RCLootCouncil:SendCommand(target, command, ...)
 	elseif target == "guild" then
 		self:SendCommMessage("RCLootCouncil", toSend, "GUILD")
 
+	elseif target == "council" then -- This cost large bandwidth, use this only for small command. 
+									-- Only send data to council, for security.
+		if self.mldb.observe or #self.council >= GetNumGroupMembers() then -- Everyone can see the voting frame, just send to the entire group
+			self:SendCommand("group", command, ...)
+		elseif not tContains(self.council, self.masterLooter) then -- council is invalid because it does not contain ML, just send to the entire group so we don't break stuffs.
+			self:Debug("SendCommand to council, but council does not contain ML", self.masterLooter)
+			self:SendCommand("group", command, ...)
+		else
+			self:SendCommand(self.masterLooter, command, ...) -- Send to ML first
+			for _, v in ipairs(self.council) do
+				if v ~= self.masterLooter then -- Then other councilmen
+					self:SendCommand(v, command, ...)
+				end
+			end
+		end
 	else
 		if self:UnitIsUnit(target,"player") then -- If target == "player"
 			self:SendCommMessage("RCLootCouncil", toSend, "WHISPER", self.playerName)


### PR DESCRIPTION
+ Non-council members can easily see the voting frame, by adding one or two lines of code in RC
+ This code makes RC more secure. Send actual response and vote only to council members.

---
#### Potential problems'
+ We must make sure everyone in the group receives up-to-date council list, otherwise we have problems. I have made another PR to do it.
+ We send one message for every council we have, so it has performance problem when there are too many councilmen.
   + However, commands we send to council are all less than 100 bytes, so it should be fine.