### PR TITLE
Dont use == to compare item link

### DIFF
--- a/Modules/lootFrame.lua
+++ b/Modules/lootFrame.lua
@@ -52,7 +52,7 @@ function LootFrame:Start(table, reRoll)
 	for k = offset+1, offset+#table do -- Only check the entries we added just now.
 		if not items[k].rolled then
 			for j = offset+1, offset+#table do
-				if j ~= k and items[k].link == items[j].link and not items[j].rolled then
+				if j ~= k and addon:ItemIsItem(items[k].link, items[j].link) and not items[j].rolled then
 					tinsert(items[k].sessions, items[j].sessions[1])
 					items[j].rolled = true -- Pretend we have rolled it.
 					numRolled = numRolled + 1

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -1158,7 +1158,7 @@ do
 				func = function(candidateName)
 					local t = {}
 					for k,v in ipairs(lootTable) do
-						if k==session or (v.link == lootTable[session].link and not v.awarded) then
+						if k==session or (addon:ItemIsItem(v.link, lootTable[session].link) and not v.awarded) then
 							tinsert(t, {
 								name = v.name,
 								link = v.link,

--- a/core.lua
+++ b/core.lua
@@ -1719,6 +1719,20 @@ function RCLootCouncil:GetItemNameFromLink(link)
 	return strmatch(link or "", "%[(.+)%]")
 end
 
+-- The link of same item generated from different player, or if two links are generated between player spec switch, are NOT the same
+-- Because item link contains player's level and spec ID.
+-- This function compares link with link level and spec ID removed.
+-- Also compare with unique id removed, because wowpedia says that 
+-- " In-game testing indicates that the UniqueId can change from the first loot to successive loots on the same item."
+-- Although log shows item in the loot actually has no uniqueId in Legion, but just in case Blizzard changes it in the future.
+-- @return true if two items are the same item
+function RCLootCouncil:ItemIsItem(item1, item2)
+	if type(item1) ~= "string" or type(item2) ~= "string" then return item1 == item2 end
+	local pattern = "|Hitem:(%d*):(%d*):(%d*):(%d*):(%d*):(%d*):(%d*):%d*:%d*:%d*"
+	local replacement = "|Hitem:%1:%2:%3:%4:%5:%6:%7:::" -- Compare link with uniqueId, linkLevel and SpecID removed
+	return item1:gsub(pattern, replacement) == item2:gsub(pattern, replacement)
+end
+
 --@param links. Table of links. Any link in the table can contain connected links (links without space in between)
 --@return a list of links that contains all spilited item links
 function RCLootCouncil:GetSplitedLinks(links)

--- a/ml_core.lua
+++ b/ml_core.lua
@@ -441,7 +441,7 @@ function RCLootCouncilML:UpdateLootSlots()
 		for session = 1, #self.lootTable do
 			-- Just skip if we've already awarded the item or found a fitting lootSlot
 			if not self.lootTable[session].awarded and not updatedLootSlot[session] then
-				if item == self.lootTable[session].link then
+				if addon:ItemIsItem(item, self.lootTable[session].link) then
 					if i ~= self.lootTable[session].lootSlot then -- It has changed!
 						addon:DebugLog("lootSlot @session", session, "Was at:",self.lootTable[session].lootSlot, "is now at:", i)
 						self.lootTable[session].lootSlot = i -- update it
@@ -546,7 +546,7 @@ function RCLootCouncilML:Award(session, winner, response, reason)
 				return awardFailed(session, winner, "loot_not_open")
 			end
 			-- v2.4.4+: Check if the item is still in the expected slot
-			if self.lootTable[session].link ~= GetLootSlotLink(self.lootTable[session].lootSlot) then
+			if not addon:ItemIsItem(self.lootTable[session].link, GetLootSlotLink(self.lootTable[session].lootSlot)) then
 				addon:Debug("LootSlot has changed before award!", session)
 				-- And update them if not
 				self:UpdateLootSlots()
@@ -918,7 +918,7 @@ function RCLootCouncilML:GetItemsFromMessage(msg, sender, retryCount)
 	local link = self.lootTable[ses].link
 	-- Send Responses to all duplicate items.
 	for s, v in ipairs(self.lootTable) do
-		if v.link == link then
+		if addon:ItemIsItem(v.link, link) then
 			addon:SendCommand("group", "response", s, sender, toSend)
 			count = count + 1
 		end


### PR DESCRIPTION
```
-- The link of same item generated from different player, or if two links are generated between player spec switch, are NOT the same
-- Because item link contains player's level and spec ID.
-- This function compares link with link level and spec ID removed.
-- Also compare with unique id removed, because wowpedia says that 
-- " In-game testing indicates that the UniqueId can change from the first loot to successive loots on the same item."
-- Although log shows item in the loot actually has no uniqueId in Legion, but just in case Blizzard changes it in the future.
function RCLootCouncil:ItemIsItem(item1, item2)
```
---

Compare item link by ==  fail if the item link is generated by different player, or by the same player after changing spec. Currently there is a bug when ML switches spec when looting. Anyway, it is not secure to compare link directly by ==, similar to why we compare unit by self:UnitIsUnit

---
#### Changelog
+ Add function ```RCLootCouncil:ItemIsItem(item1, item2)``` to compare item.
+ All link comparison now uses ```RCLootCouncil:ItemIsItem```