### PR TITLE
Duplicate items should have same roll

### DIFF
--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -307,9 +307,7 @@ function RCVotingFrame:Setup(table)
 	self:BuildST()
 	self:SwitchSession(session)
 	if addon.isMasterLooter and db.autoAddRolls then 
-		for i = 1, #lootTable do 
-			self:DoRandomRolls(i) 
-		end 
+		self:DoAllRandomRolls()
 	end
 end
 
@@ -333,7 +331,7 @@ end
 
 function RCVotingFrame:DoRandomRolls(ses)
 	local table = {}
-	for name, v in pairs (lootTable[ses].candidates) do
+	for name, _ in pairs (lootTable[ses].candidates) do
 		table[name] = math.random(100)
 	end
 
@@ -342,6 +340,26 @@ function RCVotingFrame:DoRandomRolls(ses)
 			addon:SendCommand("group", "rolls", k, table)
 		end
 	end
+end
+
+function RCVotingFrame:DoAllRandomRolls()
+	local sessionsDone = {}
+
+	for ses, t in ipairs(lootTable) do
+		if not sessionsDone[ses] then
+			local table = {}
+			for name, _ in pairs (lootTable[ses].candidates) do
+				table[name] = math.random(100)
+			end
+			for k, v in ipairs(lootTable) do
+				if addon:ItemIsItem(t.link, v.link) then
+					sessionsDone[k] = true
+					addon:SendCommand("group", "rolls", k, table)
+				end
+			end
+		end
+	end
+
 end
 
 ----------------------------------------------------------------- -

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -336,12 +336,7 @@ function RCVotingFrame:DoRandomRolls(ses)
 	for name, v in pairs (lootTable[ses].candidates) do
 		table[name] = math.random(100)
 	end
-
-	for k, v in ipairs(lootTable) do
-		if addon:ItemIsItem(lootTable[session].link, v.link) then
-			addon:SendCommand("group", "rolls", k, table)
-		end
-	end
+	addon:SendCommand("group", "rolls", ses, table)
 end
 
 ----------------------------------------------------------------- -

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -338,7 +338,7 @@ function RCVotingFrame:DoRandomRolls(ses)
 	end
 
 	for k, v in ipairs(lootTable) do
-		if addon:ItemIsItem(lootTable[session].link, v.link) then
+		if addon:ItemIsItem(lootTable[ses].link, v.link) then
 			addon:SendCommand("group", "rolls", k, table)
 		end
 	end

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -306,7 +306,11 @@ function RCVotingFrame:Setup(table)
 	session = 1
 	self:BuildST()
 	self:SwitchSession(session)
-	if db.autoAddRolls then for i = 1, #lootTable do self:DoRandomRolls(i) end end
+	if addon.isMasterLooter and db.autoAddRolls then 
+		for i = 1, #lootTable do 
+			self:DoRandomRolls(i) 
+		end 
+	end
 end
 
 function RCVotingFrame:HandleVote(session, name, vote, voter)

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -336,7 +336,12 @@ function RCVotingFrame:DoRandomRolls(ses)
 	for name, v in pairs (lootTable[ses].candidates) do
 		table[name] = math.random(100)
 	end
-	addon:SendCommand("group", "rolls", ses, table)
+
+	for k, v in ipairs(lootTable) do
+		if addon:ItemIsItem(lootTable[session].link, v.link) then
+			addon:SendCommand("group", "rolls", k, table)
+		end
+	end
 end
 
 ----------------------------------------------------------------- -

--- a/core.lua
+++ b/core.lua
@@ -1719,6 +1719,20 @@ function RCLootCouncil:GetItemNameFromLink(link)
 	return strmatch(link or "", "%[(.+)%]")
 end
 
+-- The link of same item generated from different player, or if two links are generated between player spec switch, are NOT the same
+-- Because item link contains player's level and spec ID.
+-- This function compares link with link level and spec ID removed.
+-- Also compare with unique id removed, because wowpedia says that 
+-- " In-game testing indicates that the UniqueId can change from the first loot to successive loots on the same item."
+-- Although log shows item in the loot actually has no uniqueId in Legion, but just in case Blizzard changes it in the future.
+-- @return true if two items are the same item
+function RCLootCouncil:ItemIsItem(item1, item2)
+	if type(item1) ~= "string" or type(item2) ~= "string" then return item1 == item2 end
+	local pattern = "|Hitem:(%d*):(%d*):(%d*):(%d*):(%d*):(%d*):(%d*):%d*:%d*:%d*"
+	local replacement = "|Hitem:%1:%2:%3:%4:%5:%6:%7:::" -- Compare link with uniqueId, linkLevel and SpecID removed
+	return item1:gsub(pattern, replacement) == item2:gsub(pattern, replacement)
+end
+
 --@param links. Table of links. Any link in the table can contain connected links (links without space in between)
 --@return a list of links that contains all spilited item links
 function RCLootCouncil:GetSplitedLinks(links)


### PR DESCRIPTION
+ Manual roll should set rolls for all duplicate items. No one does two manual rolls for two instances of the same item
+ Fix a bug that non-ML council could send unnecessary roll commands if autoRolls is enabled.
+ The original roll feature also sets the same roll for duplicate items.
  + This is debatable, but if we roll on the duplicate items, we usually award the 1st item to the highest rolled candidate, 2nd item to the 2nd highest rolled candidate. I do think this makes sense.
+ The algorithm to generate random numbers is changed. Now it is guaranteed that every candidate has different roll, if the random numbers are generated by RC.
  + There was a ticket on Curseforge [#299](https://wow.curseforge.com/projects/rclootcouncil/issues/299) complaining that rolls can be the same and request the roll to be floating number and that idea was rejected by you. This solution is way better to solve that.