### PR TITLE
30s default timeout is too short

### DIFF
--- a/Modules/options.lua
+++ b/Modules/options.lua
@@ -963,7 +963,7 @@ function addon:OptionsTable()
 											if self.db.profile.timeout then
 												self.db.profile.timeout = false
 											else
-												self.db.profile.timeout = 30
+												self.db.profile.timeout = 180
 											end
 										end,
 										get = function()

--- a/core.lua
+++ b/core.lua
@@ -284,7 +284,7 @@ function RCLootCouncil:OnInitialize()
 			},
 			disenchant = true, -- Disenchant enabled, i.e. there's a true in awardReasons.disenchant
 
-			timeout = 30,
+			timeout = 180,
 
 			-- List of items to ignore:
 			ignore = {


### PR DESCRIPTION
+ 30s default timeout is too short and this is very annoying default setting for new RCLootCouncil user. Let's set it to 180s, which is the Blizzard timeout for bonus rolls confirmation.
  + I prefer this setting over disable timeout by default, because this teaches the user a timeout feature exists.