### PR TITLE
Fix a nil error in response sort of loot history

### DIFF
--- a/Modules/lootHistory.lua
+++ b/Modules/lootHistory.lua
@@ -340,9 +340,9 @@ function LootHistory.ResponseSort(table, rowa, rowb, sortbycol)
 	-- NOTE: I'm pretty sure it can only be an awardReason when responseID is nil or 0
 	if aID and aID ~= 0 then
 		if lootDB[rowa.name][rowa.num].isAwardReason then
-			a = db.awardReasons[aID].sort
+			a = db.awardReasons[aID] and db.awardReasons[aID].sort or 500
 		else
-			a = addon:GetResponseSort(aID)
+			a = addon:GetResponseSort(aID) or 500
 		end
 	else
 		-- 500 will be below award reasons and just above status texts
@@ -351,9 +351,9 @@ function LootHistory.ResponseSort(table, rowa, rowb, sortbycol)
 
 	if bID and bID ~= 0 then
 		if lootDB[rowb.name][rowb.num].isAwardReason then
-			b = db.awardReasons[bID].sort
+			b = db.awardReasons[bID] and db.awardReasons[bID].sort or 500
 		else
-			b = addon:GetResponseSort(bID)
+			b = addon:GetResponseSort(bID) or 500
 		end
 
 	else


### PR DESCRIPTION
Although this error is definitely related to my saved variable, let's have an extra nil check.
```
1x RCLootCouncil\Modules\lootHistory.lua:343: attempt to index field '?' (a nil value)
RCLootCouncil\Modules\lootHistory.lua:343: in function <RCLootCouncil\Modules\lootHistory.lua:334>
(tail call): ?
[C]: in function `sort'
RCLootCouncil\Libs\lib-st\Core.lua:301: in function `SortData'
RCLootCouncil\Libs\lib-st\Core.lua:682: in function `?'
RCLootCouncil\Libs\lib-st\Core.lua:53: in function `FireUserEvent'
RCLootCouncil\Libs\lib-st\Core.lua:96: in function <RCLootCouncil\Libs\lib-st\Core.lua:95>
```