### PR TITLE
Award sets the response to Awarded

### DIFF
--- a/Locale/enUS.lua
+++ b/Locale/enUS.lua
@@ -97,6 +97,7 @@ L["Award later?"] = true
 L["Award later isn't supported when testing."] = true
 L["Award Reasons"] = true
 L["Award"] = true
+L["Awarded"] = true
 L["award_reasons_desc"] = "Award reasons that can't be chosen during a roll.\nUsed when changing a response with the right click menu and for Auto Awards.\n"
 L["Awarded item cannot be awarded later."] = true
 L["Awards"] = true

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -183,6 +183,11 @@ function RCVotingFrame:OnCommReceived(prefix, serializedMsg, distri, sender)
 				local s, winner = unpack(data)
 				if not lootTable[s] then return end -- We might not have lootTable - e.g. if we just reloaded
 				lootTable[s].awarded = winner
+				for k, v in ipairs(lootTable) do
+					if addon:ItemIsItem(v.link, lootTable[session].link) then
+						self:SetCandidateData(k, winner, "response", "AWARDED")
+					end
+				end
 				if addon.isMasterLooter and session ~= #lootTable then -- ML should move to the next item on award
 					self:SwitchSession(session + 1)
 				else

--- a/core.lua
+++ b/core.lua
@@ -106,6 +106,7 @@ function RCLootCouncil:OnInitialize()
 	self.council = {} -- council from ML
 	self.mldb = {} -- db recived from ML
 	self.responses = {
+		AWARDED         = { color = {0,0,1,1},				sort = 500,		text = L["Awarded"],},
 		NOTANNOUNCED	= { color = {1,0,1,1},				sort = 501,		text = L["Not announced"],},
 		ANNOUNCED		= { color = {1,0,1,1},				sort = 502,		text = L["Loot announced, waiting for answer"], },
 		WAIT				= { color = {1,1,0,1},				sort = 503,		text = L["Candidate is selecting response, please wait"], },


### PR DESCRIPTION
+ When the item is awarded, sets the response of the awardee to "Awarded" to all duplicate items, so I don't need to remember who have been awarded one of the duplicate items, so I never mistakenly award two identical items to the same people
+ This breaks backward compatibility though