### PR TITLE
Fix nil in GetML

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -1826,7 +1826,10 @@ function RCLootCouncil:GetML()
 		local name;
 		for i=1, GetNumGroupMembers() or 0 do
 			local name2, rank = GetRaidRosterInfo(i)
-			if rank == 2 then -- Group leader
+			if not name2 then -- Group info is not completely ready
+				return false, "Unknown"
+			end
+			if rank == 2 then -- Group leader. Btw, name2 can be nil when rank is 2.
 				name = self:UnitName(name2)
 			end
 		end


### PR DESCRIPTION
It's posssible that the first return value of GetRaidRosterInfo is nil, when the 2nd return value is not nil