### PR TITLE
Need to use SortData() twice to correctly sort response after rolls

### DIFF
--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -429,6 +429,7 @@ function RCVotingFrame:Update()
 	if not self.frame then return end -- No updates when it doesn't exist
 	if not lootTable[session] then return addon:Debug("VotingFrame:Update() without lootTable!!") end -- No updates if lootTable doesn't exist.
 	self.frame.st:SortData()
+	self.frame.st:SortData() -- It appears that there is a bug in lib-st that only one SortData() does not use the "sortnext" to correct sort the rows.
 	-- update awardString
 	if lootTable[session] and lootTable[session].awarded then
 		self.frame.awardString:SetText(L["Item was awarded to"])


### PR DESCRIPTION
If you are not going to merge #92 , then at least merge this.
This is an issue in Lib-scrollTable that one sortData does not correctly sort responses after rolls, if roll gets updated.
Use SortData twice solves the problem