### PR TITLE
Fix loot table sorting

### DIFF
--- a/ml_core.lua
+++ b/ml_core.lua
@@ -1651,34 +1651,6 @@ RCLootCouncilML.EQUIPLOC_SORT_ORDER = {
 RCLootCouncilML.EQUIPLOC_SORT_ORDER = tInvert(RCLootCouncilML.EQUIPLOC_SORT_ORDER)
 RCLootCouncilML.EQUIPLOC_SORT_ORDER["INVTYPE_ROBE"] = RCLootCouncilML.EQUIPLOC_SORT_ORDER["INVTYPE_CHEST"] -- Chest is the same as robe
 
--- TRANSFORMED to 'SUBTYPE_SORT_ORDER["SUBTYPE"] = num', below
-RCLootCouncilML.SUBTYPE_SORT_ORDER = {
-	"Junk", -- armor token
-	"Plate",
-	"Mail",
-	"Leather",
-	"Cloth",
-	"Shields",
-	"Bows",
-	"Crossbows",
-	"Daggers",
-	"Guns",
-	"Fist Weapons",
-	"One-Handed Axes",
-	"One-Handed Maces",
-	"One-Handed Swords",
-	"Polearms",
-	"Staves",
-	"Two-Handed Axes",
-	"Two-Handed Maces",
-	"Two-Handed Swords",
-	"Wands",
-	"Warglaives",
-	"Miscellaneous",
-	"Artifact Relic",
-}
-RCLootCouncilML.SUBTYPE_SORT_ORDER = tInvert(RCLootCouncilML.SUBTYPE_SORT_ORDER)
-
 function RCLootCouncilML:SortLootTable(lootTable)
 	table.sort(lootTable, self.LootTableCompare)
 end
@@ -1712,10 +1684,11 @@ function RCLootCouncilML.LootTableCompare(a, b)
 	if equipLocA ~= equipLocB then
 		return equipLocA < equipLocB
 	end
-	local subTypeA = RCLootCouncilML.SUBTYPE_SORT_ORDER[addon.db.global.localizedSubTypes[a.subType]] or math.huge
-	local subTypeB = RCLootCouncilML.SUBTYPE_SORT_ORDER[addon.db.global.localizedSubTypes[b.subType]] or math.huge
-	if subTypeA ~= subTypeB then
-		return subTypeA < subTypeB
+	if a.typeID ~= b.typeID then
+		return a.typeID > b.typeID
+	end
+	if a.subTypeID ~= b.subTypeID then
+		return a.subTypeID < b.subTypeID
 	end
 	if a.relic ~= b.relic then
 		if a.relic and b.relic then

--- a/ml_core.lua
+++ b/ml_core.lua
@@ -1688,7 +1688,7 @@ function RCLootCouncilML.LootTableCompare(a, b)
 		return a.typeID > b.typeID
 	end
 	if a.subTypeID ~= b.subTypeID then
-		return a.subTypeID < b.subTypeID
+		return a.subTypeID > b.subTypeID
 	end
 	if a.relic ~= b.relic then
 		if a.relic and b.relic then


### PR DESCRIPTION
+ Complete forget to edit this when localized subType is removed.
+ The sort order is the same as before the fix. (Except weapon is sorted after relic now, but there is no weapon in this expansion, so doesn't matter.)
+ This is the reason why we should clear our saved variables when testing.