### PR TITLE
Attempt to fix mldb

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -1771,6 +1771,7 @@ function RCLootCouncil:NewMLCheck()
 		-- At this point we know the ML has changed, so we can wipe the council
 		self:Debug("Resetting council as we have a new ML!")
 		self.council = {}
+		self.mldb = {}
 		self.isCouncil = false
 		self:Debug("MasterLooter = ", self.masterLooter)
 		-- Check to see if we have recieved mldb within 15 secs, otherwise request it

--- a/core.lua
+++ b/core.lua
@@ -787,6 +787,7 @@ function RCLootCouncil:OnCommReceived(prefix, serializedMsg, distri, sender)
 			elseif command == "MLdb" and not self.isMasterLooter then -- ML sets his own mldb
 				--[[ NOTE: 2.1.7 - While a check for this does make sense, I'm just really tired of mldb problems, and
 					noone should really be able to send it without being ML in the first place. So just accept it as is. ]]
+				-- [[2.7: Probably should still check this. There are issues otherwise.]]
 				if self:UnitIsUnit(sender, self.masterLooter) then
 					self.mldb = unpack(data)
 				else

--- a/core.lua
+++ b/core.lua
@@ -787,11 +787,11 @@ function RCLootCouncil:OnCommReceived(prefix, serializedMsg, distri, sender)
 			elseif command == "MLdb" and not self.isMasterLooter then -- ML sets his own mldb
 				--[[ NOTE: 2.1.7 - While a check for this does make sense, I'm just really tired of mldb problems, and
 					noone should really be able to send it without being ML in the first place. So just accept it as is. ]]
-				--if self:UnitIsUnit(sender, self.masterLooter) then
+				if self:UnitIsUnit(sender, self.masterLooter) then
 					self.mldb = unpack(data)
-				--else
-				--	self:Debug("Non-ML:", sender, "sent Mldb!")
-				--end
+				else
+					self:Debug("Non-ML:", sender, "sent Mldb!")
+				end
 
 			elseif command == "verTest" and not self:UnitIsUnit(sender, "player") then -- Don't reply to our own verTests
 				local otherVersion, tVersion = unpack(data)


### PR DESCRIPTION
+ When receiving MLdb, we should check if it is from the ML.
  + I suspect this is the reason of the recent reports of MLdb is not being received because some non-ML enables ML module and send MLdb
  + Even if this is not the reason, we should always check it, in case someone's version messes up
  + Although you claimed long ago " NOTE: 2.1.7 - While a check for this does make sense, I'm just really tired of mldb problems, and noone should really be able to send it without being ML in the first place. So just accept it as is.", but this is really never the reason why the mldb is not received. Not checking this only creates problem when any non-ML somehow sends mldb. We should always check if the ml commands are from the ml.
+ Also clear mldb when ml changes.
   + Then, we'll only have either no mldb, or mldb of the current ML. We'll never have mldb of someone else. If somehow mldb is not received, this is be detected in OnCommReceived and mldb should be resended.
   + I have considered to also clear ```self.candidate```, but that's also a part of data sent by ml.