### PR TITLE
Delay LOOT_OPENED event handling when encounter an uncached item.

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -1710,32 +1710,31 @@ function RCLootCouncil:OnEvent(event, ...)
 		if select(1, ...) ~= "scheduled" and self.LootOpenScheduled then return end -- When this function is scheduled to run again, but LOOT_OPENDED event fires, return.
 		self.LootOpenScheduled = false
 		wipe(self.lootSlotInfo)
+		if GetNumLootItems() <= 0 then return end-- In case when function rerun, loot window is closed.
 
-		if GetNumLootItems() > 0 then -- In case when function rerun, loot window is closed.
-			self.lootOpen = true
-			for i = 1,  GetNumLootItems() do
-				if LootSlotHasItem(i) then
-					local texture, name, quantity, quality, locked, isQuestItem, questId, isActive = GetLootSlotInfo(i)
-					local link = GetLootSlotLink(i)
-					if texture then
-						self.lootSlotInfo[i] = {
-							name = name,
-							link = link, -- This could be nil, if the item is money.
-							quantity = quantity,
-							quality = quality,
-							locked = locked,
-						}
-					else -- It's possible that item in the loot window is uncached. Retry in the next frame.
-						self:Debug("Loot uncached when the loot window is opened. Retry in the next frame.", link)
-						self.LootOpenScheduled = true
-						-- Must offer special argument as 2nd argument to indicate this is run from scheduler.
-						return self:ScheduleTimer("OnEvent", 0, "LOOT_OPENED", "scheduled")
-					end
+		self.lootOpen = true
+		for i = 1,  GetNumLootItems() do
+			if LootSlotHasItem(i) then
+				local texture, name, quantity, quality, locked, isQuestItem, questId, isActive = GetLootSlotInfo(i)
+				local link = GetLootSlotLink(i)
+				if texture then
+					self.lootSlotInfo[i] = {
+						name = name,
+						link = link, -- This could be nil, if the item is money.
+						quantity = quantity,
+						quality = quality,
+						locked = locked,
+					}
+				else -- It's possible that item in the loot window is uncached. Retry in the next frame.
+					self:Debug("Loot uncached when the loot window is opened. Retry in the next frame.", link)
+					self.LootOpenScheduled = true
+					-- Must offer special argument as 2nd argument to indicate this is run from scheduler.
+					return self:ScheduleTimer("OnEvent", 0, "LOOT_OPENED", "scheduled")
 				end
 			end
-			if self.isMasterLooter then
-				self:GetActiveModule("masterlooter"):OnLootOpen()
-			end
+		end
+		if self.isMasterLooter then
+			self:GetActiveModule("masterlooter"):OnLootOpen()
 		end
 	elseif event == "LOOT_CLOSED" then
 		self:Debug("Event:", event, ...)

--- a/ml_core.lua
+++ b/ml_core.lua
@@ -773,17 +773,20 @@ function RCLootCouncilML:LootOpened()
 			self:UpdateLootSlots()
 		else -- Otherwise add the loot
 			for i = 1, GetNumLootItems() do
-				local item = GetLootSlotLink(i)
-				if db.altClickLooting then self:ScheduleTimer("HookLootButton", 0.5, i) end -- Delay lootbutton hooking to ensure other addons have had time to build their frames
-				local _, _, quantity, quality = GetLootSlotInfo(i)
-				if self:ShouldAutoAward(item, quality) and quantity > 0 then
-					self:AutoAward(i, item, quality, db.autoAwardTo, db.autoAwardReason, addon.bossName)
+				if addon.lootSlotInfo[i] then
+					local item = addon.lootSlotInfo[i].link -- This can be nil, if this is money(a coin).
+					local quantity = addon.lootSlotInfo[i].quantity
+					local quality = addon.lootSlotInfo[i].quality
+					if db.altClickLooting then self:ScheduleTimer("HookLootButton", 0.5, i) end -- Delay lootbutton hooking to ensure other addons have had time to build their frames
+					if item and self:ShouldAutoAward(item, quality) and quantity > 0 then
+						self:AutoAward(i, item, quality, db.autoAwardTo, db.autoAwardReason, addon.bossName)
 
-				elseif self:CanWeLootItem(item, quality) and quantity > 0 then -- check if our options allows us to loot it
-					self:AddItem(item, false, i)
+					elseif item and self:CanWeLootItem(item, quality) and quantity > 0 then -- check if our options allows us to loot it
+						self:AddItem(item, false, i)
 
-				elseif quantity == 0 then -- it's coin, just loot it
-					LootSlot(i)
+					elseif quantity == 0 then -- it's coin, just loot it
+						LootSlot(i)
+					end
 				end
 			end
 		end


### PR DESCRIPTION
+ The recent error report shows that it is no longer guaranteed that the info of items in loot slot is ready when the loot window opens.
  + Retry in the next frame if get any uncached item.
  + Retry in the next frame instead of 1s, because I follow Blizzard code which retries in the next frame.
```
-- FrameXML/LootFrame.lua, line 227
else
	text:SetText("");
	_G["LootButton"..index.."IconTexture"]:SetTexture(nil);
	SetItemButtonNormalTextureVertexColor(button, 1.0, 1.0, 1.0);
	LootFrame:SetScript("OnUpdate", LootFrame_OnUpdate);
	button:Disable();
end