### PR TITLE
Add sigil of the dark titan to ignoredItems

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -307,6 +307,7 @@ function RCLootCouncil:OnInitialize()
 				[143656] = true, [143657] = true, [143658] = true, -- Echo of Time (Nighthold quest item)
 				[132204] = true, [151248] = true, [151249] = true, [151250] = true, -- Sticky Volatile Essence, Fragment of the Guardian's Seal (Tomb of Sargeras)
 				[152902] = true, [152906] = true, [152907] = true, [155831] = true, -- Rune of Passage (Antorus shortcut item), Pantheon's Blessing
+				[152908] = true, [152909] = true, [152910] = true, -- Sigil of the Dark Titan (Another Antorus shortcut item)
 			},
 		},
 	} -- defaults end


### PR DESCRIPTION
+ I think add default ignored items should no longer be necessary in the future.
   + RC should only loots equipable+relic+mount+tiers. We actually don't need "loot everything" option. Dont think there is any other item that can be master looted.
   + Tiers can be recognized by parsing tooltip of "Class: xxx", or using ```GetItemSpell```
   + The easier way is to check the GetMasterLootCandidate, if there is no other person except ML, dont add it to the session.