### PR TITLE
Attempt to fix disconnection

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -1397,7 +1397,10 @@ function RCLootCouncil:AutoResponse(table)
 			end
 		end
 		-- target, session, response, isTier, isRelic, note, roll, link, ilvl, equipLoc, relicType, sendAvgIlvl, sendSpecID
-		self:SendResponse("group", session, response, nil, nil, nil, nil, v.link, v.ilvl, v.equipLoc, v.relic, true, true)
+		-- v2.7.1: Disconnection reported in large raid. It's likely that it is caused by the large amount of responses received in a short time frame.
+		-- First, delay by 1s, so people won't receive response within the same second of lootTable
+		-- Second, delay incremental short time for each session, to avoid message bursts when lots of items or in large raid.
+		self:ScheduleTimer("SendResponse", 1+0.5*(k-1), "group", session, response, nil, nil, nil, nil, v.link, v.ilvl, v.equipLoc, v.relic, true, true)
 	end
 end
 

--- a/ml_core.lua
+++ b/ml_core.lua
@@ -641,7 +641,7 @@ function RCLootCouncilML:OnCommReceived(prefix, serializedMsg, distri, sender)
 				addon:Debug("Responded to reconnect from", sender)
 			elseif command == "lootTable" and addon:UnitIsUnit(sender, addon.playerName) then
 				-- Start a timer to set response as offline/not installed unless we receive an ack
-				self:ScheduleTimer("Timer", 10, "LootSend")
+				self:ScheduleTimer("Timer", 15, "LootSend")
 
 			elseif command == "tradable" then -- Raid members send the info of the tradable item he looted.
 				local item = unpack(data)

--- a/ml_core.lua
+++ b/ml_core.lua
@@ -641,7 +641,7 @@ function RCLootCouncilML:OnCommReceived(prefix, serializedMsg, distri, sender)
 				addon:Debug("Responded to reconnect from", sender)
 			elseif command == "lootTable" and addon:UnitIsUnit(sender, addon.playerName) then
 				-- Start a timer to set response as offline/not installed unless we receive an ack
-				self:ScheduleTimer("Timer", 15, "LootSend")
+				self:ScheduleTimer("Timer", 11 + 0.5*#self.lootTable, "LootSend")
 
 			elseif command == "tradable" then -- Raid members send the info of the tradable item he looted.
 				local item = unpack(data)


### PR DESCRIPTION
https://media-elerium.cursecdn.com/attachments/220/817/rclootcouncil.txt
Disconnection happens on entry 309, but the lootTable is received on entry 98.
About 200 addon messages are received within 1s.

I highly suspect the disconnection is caused by burst traffic due to the following reasons:
1. It seems only happens in large raid. More likely in 30man raid. No reports for small raid.
2. It only happens when loot frame pops up when there are lots of traffic happening.
3. Happens randomly, and does not happen for everyone. I think it is because some server is has lower data threshold than the others.

---
http://wowwiki.wikia.com/wiki/ChatThrottleLib
> The World of Warcraft servers will disconnect you if you generate too much output. This is not limited to chat output; any type of output can cause it. Some of you may have noticed that holding down your right mouse button and wiggling it wildly for an extended time can kick you off.

I suppose receiving message also generates output because WoW client generates ACK for each message? Anyway, it's highly likely that the burst traffic when the lootTable received causes the issue.

---
Why the problem arises in this version but not the older version?
1. This version increases the traffic a bit because non-autopass people sends their gear immediately. 
2. it's possible that Blizzard lower the disconnection threshold to handle the much more online people in the new raid.
3. 30man raid only occurs at the start of tier. People don't 30man raid at the end tier. Disconnection shouldn't happen in small raid.

---

RCLootCouncil3 will reduce the traffic by:
1. Compress data: All information fetch-able client side in itemLink will be discarded, such as quality color and item name
2. Combine short commands into large one. If short commands are sent together, we should combine them into one because more commands=more overhead. For example, combines several ```response``` command into ```multi_response``` command.

---
+ I know this causes delay when all items are distributed later, but distributes lots of items takes time. I don't think 30s matters time for distributing 60 items, and there isn't much delay if the items are distributes from the 1st session to the last session