### PR TITLE
Always show tooltip on voting frame

### DIFF
--- a/Locale/enUS.lua
+++ b/Locale/enUS.lua
@@ -44,6 +44,7 @@ L["alt_click_looting_desc"] = "Enables Alt click Looting, i.e. start a looting s
 L["Alternatively, flag the loot as award later."] = true
 L["Always use RCLootCouncil when I'm Master Looter"] = true
 L["Always use when leader"] = true
+L["always_show_tooltip_howto"] = "Double click to always show tooltip or cancel it"
 L["Announce Awards"] = true
 L["Announce Considerations"] = true
 L["announce_awards_desc"] = "Enables the announcement of awards in chat."

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -628,15 +628,7 @@ function RCVotingFrame:GetFrame()
 	item:SetSize(50,50)
 	f.itemIcon = item
 
-	local itemTooltip = CreateFrame("GameTooltip", "RCVotingFrame_ItemTooltip", f.content, "GameTooltipTemplate")
-	itemTooltip:SetClampedToScreen(false)
-	-- Some addons hook GameTooltip. So copy the hook.
- 	itemTooltip:SetScript("OnTooltipSetItem", GameTooltip:GetScript("OnTooltipSetItem"))
- 	itemTooltip.shoppingTooltips = {} -- GameTooltip contains this table.
- 	itemTooltip.shoppingTooltips[1] = CreateFrame("GameTooltip", "RCVotingFrame_ItemTooltip_Shop1", itemTooltip, "ShoppingTooltipTemplate")
- 	itemTooltip.shoppingTooltips[2] = CreateFrame("GameTooltip", "RCVotingFrame_ItemTooltip_Shop2", itemTooltip, "ShoppingTooltipTemplate")
-	f.itemTooltip = itemTooltip
-
+	f.itemTooltip = addon:CreateGameTooltip("votingframe", f.content)
 
 	local iTxt = f.content:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
 	iTxt:SetPoint("TOPLEFT", item, "TOPRIGHT", 10, 0)

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -603,7 +603,6 @@ function RCVotingFrame:GetFrame()
 		Session item icon and strings
 	    ------------------------------]]
 	local item = CreateFrame("Button", nil, f.content)
-	--item:EnableMouse()
     item:SetNormalTexture("Interface/ICONS/INV_Misc_QuestionMark")
     item:SetScript("OnEnter", function()
 		if not lootTable then return; end
@@ -627,12 +626,11 @@ function RCVotingFrame:GetFrame()
     end);
 	item:SetPoint("TOPLEFT", f, "TOPLEFT", 10, -20)
 	item:SetSize(50,50)
-
 	f.itemIcon = item
 
 	local itemTooltip = CreateFrame("GameTooltip", "RCVotingFrame_ItemTooltip", f.content, "GameTooltipTemplate")
 	itemTooltip:SetClampedToScreen(false)
-	-- Some addon hooks GameTooltip. So copy the hook.
+	-- Some addons hook GameTooltip. So copy the hook.
  	itemTooltip:SetScript("OnTooltipSetItem", GameTooltip:GetScript("OnTooltipSetItem"))
  	itemTooltip.shoppingTooltips = {} -- GameTooltip contains this table.
  	itemTooltip.shoppingTooltips[1] = CreateFrame("GameTooltip", "RCVotingFrame_ItemTooltip_Shop1", itemTooltip, "ShoppingTooltipTemplate")

--- a/core.lua
+++ b/core.lua
@@ -248,6 +248,7 @@ function RCLootCouncil:OnInitialize()
 							['*'] = true
 						},
 					},
+					alwaysShowTooltip = false,
 				},
 			},
 

--- a/core.lua
+++ b/core.lua
@@ -2446,6 +2446,18 @@ function RCLootCouncil:CreateFrame(name, cName, title, width, height)
 	return f
 end
 
+-- cName is name of the module
+function RCLootCouncil:CreateGameTooltip(cName, parent)
+	local itemTooltip = CreateFrame("GameTooltip", cName.."_ItemTooltip", parent, "GameTooltipTemplate")
+	itemTooltip:SetClampedToScreen(false)
+	-- Some addons hook GameTooltip. So copy the hook.
+ 	itemTooltip:SetScript("OnTooltipSetItem", GameTooltip:GetScript("OnTooltipSetItem"))
+ 	itemTooltip.shoppingTooltips = {} -- GameTooltip contains this table. Need this to prevent error
+ 	itemTooltip.shoppingTooltips[1] = CreateFrame("GameTooltip", cName.."_ShoppingTooltip1", itemTooltip, "ShoppingTooltipTemplate")
+ 	itemTooltip.shoppingTooltips[2] = CreateFrame("GameTooltip", cName.."_ShoppingTooltip2", itemTooltip, "ShoppingTooltipTemplate")
+	return itemTooltip
+end
+
 --- Update all frames registered with RCLootCouncil:CreateFrame().
 -- Updates all the frame's colors as set in the db.
 function RCLootCouncil:UpdateFrames()


### PR DESCRIPTION
+ disabled by default
+ Double click item button to toggle.
![wowscrnshot_120517_011758](https://user-images.githubusercontent.com/30888549/33599174-2be368ac-d95a-11e7-89ec-788a71b855ca.jpg)
+ Working on always show tooltip on loot frame