### PR TITLE
Always show tooltip on loot frame

### DIFF
--- a/Locale/enUS.lua
+++ b/Locale/enUS.lua
@@ -44,6 +44,7 @@ L["alt_click_looting_desc"] = "Enables Alt click Looting, i.e. start a looting s
 L["Alternatively, flag the loot as award later."] = true
 L["Always use RCLootCouncil when I'm Master Looter"] = true
 L["Always use when leader"] = true
+L["always_show_tooltip_howto"] = "Double click to always show tooltip or cancel it"
 L["Announce Awards"] = true
 L["Announce Considerations"] = true
 L["announce_awards_desc"] = "Enables the announcement of awards in chat."

--- a/Modules/lootFrame.lua
+++ b/Modules/lootFrame.lua
@@ -129,6 +129,16 @@ function LootFrame:Update()
 	end
 	self.EntryManager:Update()
 	self.frame.content:SetHeight(numEntries * ENTRY_HEIGHT + 7)
+
+	local firstEntry = self.EntryManager.entries[1]
+	if firstEntry and addon:Getdb().modules["RCLootFrame"].alwaysShowTooltip then
+		self.frame.itemTooltip:SetOwner(self.frame.content, "ANCHOR_NONE")
+		self.frame.itemTooltip:SetHyperlink(firstEntry.item.link)
+		self.frame.itemTooltip:Show()
+		self.frame.itemTooltip:SetPoint("TOPRIGHT", firstEntry.frame, "TOPLEFT", 0, 0)
+	else
+		self.frame.itemTooltip:Hide()
+	end
 end
 
 function LootFrame:OnRoll(entry, button)
@@ -182,6 +192,7 @@ function LootFrame:GetFrame()
 	addon:DebugLog("LootFrame","GetFrame()")
 	self.frame = addon:CreateFrame("DefaultRCLootFrame", "lootframe", L["RCLootCouncil Loot Frame"], 250, 375)
 	self.frame.title:SetPoint("BOTTOM", self.frame, "TOP", 0 ,-5)
+	self.frame.itemTooltip = addon:CreateGameTooltip("lootframe", self.frame.content)
 	return self.frame
 end
 
@@ -241,12 +252,21 @@ do
 			entry.icon:SetScript("OnEnter", function()
 				if not entry.item.link then return end
 				addon:CreateHypertip(entry.item.link)
+				GameTooltip:AddLine("")
+				GameTooltip:AddLine(L["always_show_tooltip_howto"], nil, nil, nil, true)
+				GameTooltip:Show()
 			end)
 			entry.icon:SetScript("OnLeave", function() addon:HideTooltip() end)
 			entry.icon:SetScript("OnClick", function()
 				if not entry.item.link then return end
 				if ( IsModifiedClick() ) then
 					HandleModifiedItemClick(entry.item.link);
+				end
+				if entry.icon.lastClick and GetTime() - entry.icon.lastClick <= 0.5 then
+					addon:Getdb().modules["RCLootFrame"].alwaysShowTooltip = not addon:Getdb().modules["RCLootFrame"].alwaysShowTooltip
+					LootFrame:Update()
+				else
+					entry.icon.lastClick = GetTime()
 				end
 			end)
 

--- a/core.lua
+++ b/core.lua
@@ -2445,6 +2445,18 @@ function RCLootCouncil:CreateFrame(name, cName, title, width, height)
 	return f
 end
 
+-- cName is name of the module
+function RCLootCouncil:CreateGameTooltip(cName, parent)
+	local itemTooltip = CreateFrame("GameTooltip", cName.."_ItemTooltip", parent, "GameTooltipTemplate")
+	itemTooltip:SetClampedToScreen(false)
+	-- Some addons hook GameTooltip. So copy the hook.
+ 	itemTooltip:SetScript("OnTooltipSetItem", GameTooltip:GetScript("OnTooltipSetItem"))
+ 	itemTooltip.shoppingTooltips = {} -- GameTooltip contains this table. Need this to prevent error
+ 	itemTooltip.shoppingTooltips[1] = CreateFrame("GameTooltip", cName.."_ShoppingTooltip1", itemTooltip, "ShoppingTooltipTemplate")
+ 	itemTooltip.shoppingTooltips[2] = CreateFrame("GameTooltip", cName.."_ShoppingTooltip2", itemTooltip, "ShoppingTooltipTemplate")
+	return itemTooltip
+end
+
 --- Update all frames registered with RCLootCouncil:CreateFrame().
 -- Updates all the frame's colors as set in the db.
 function RCLootCouncil:UpdateFrames()

--- a/core.lua
+++ b/core.lua
@@ -248,6 +248,7 @@ function RCLootCouncil:OnInitialize()
 							['*'] = true
 						},
 					},
+					alwaysShowTooltip = false,
 				},
 			},
 


### PR DESCRIPTION
+ Very useful feature. More useful than always show tooltip on voting frame. This speed things up.
+ Always show the tooltip of the first frame
+ Double click item icon to toggle.
![wowscrnshot_120517_015241](https://user-images.githubusercontent.com/30888549/33600769-1a94da36-d95f-11e7-8933-b2b62711f2c2.jpg)
