### PR TITLE
Limit update rate to 1 frame.

### DIFF
--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -31,8 +31,8 @@ local GuildRankSort, ResponseSort -- Initialize now to avoid errors
 local defaultScrollTableData = {} -- See below
 local moreInfoData = {}
 local updateFrame = CreateFrame("FRAME") -- to ensure the update operations that does not occur, because it's within min update interval, gets updated eventually
-local needUpdate = false
-local updatedThisFrame = false
+local needUpdate = false -- Do we need to update votingframe in the next frame?
+local updatedThisFrame = false -- Have we updated in the time period of frame?
 
 function RCVotingFrame:OnInitialize()
 	-- Contains all the default data needed for the scroll table
@@ -74,9 +74,6 @@ function RCVotingFrame:OnEnable()
 	self:ScheduleTimer("CandidateCheck", 20)
 	guildRanks = addon:GetGuildRanks()
 	addon:Debug("RCVotingFrame", "enabled")
-	needUpdate = false
-	updatedThisFrame = false
-	updateFrame:Show()
 end
 
 function RCVotingFrame:OnDisable() -- We never really call this
@@ -87,15 +84,15 @@ function RCVotingFrame:OnDisable() -- We never really call this
 	active = false
 	session = 1
 	self:UnregisterAllComm()
-	needUpdate = false
-	updatedThisFrame = false
-	updateFrame:Hide()
 end
 
 function RCVotingFrame:Hide()
 	addon:Debug("Hide VotingFrame")
 	self.frame.moreInfo:Hide()
 	self.frame:Hide()
+	updateFrame:Hide()
+	needUpdate = false
+	updatedThisFrame = false
 end
 
 function RCVotingFrame:Show()
@@ -103,6 +100,9 @@ function RCVotingFrame:Show()
 		councilInGroup = addon.council
 		self.frame:Show()
 		self:SwitchSession(session)
+		updateFrame:Show()
+		needUpdate = false
+		updatedThisFrame = false
 	else
 		addon:Print(L["No session running"])
 	end

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -32,6 +32,7 @@ local defaultScrollTableData = {} -- See below
 local moreInfoData = {}
 local updateFrame = CreateFrame("FRAME") -- to ensure the update operations that does not occur, because it's within min update interval, gets updated eventually
 local needUpdate = false
+local updatedThisFrame = false
 
 function RCVotingFrame:OnInitialize()
 	-- Contains all the default data needed for the scroll table
@@ -74,6 +75,7 @@ function RCVotingFrame:OnEnable()
 	guildRanks = addon:GetGuildRanks()
 	addon:Debug("RCVotingFrame", "enabled")
 	needUpdate = false
+	updatedThisFrame = false
 	updateFrame:Show()
 end
 
@@ -86,6 +88,7 @@ function RCVotingFrame:OnDisable() -- We never really call this
 	session = 1
 	self:UnregisterAllComm()
 	needUpdate = false
+	updatedThisFrame = false
 	updateFrame:Hide()
 end
 
@@ -434,12 +437,11 @@ end
 --	Visuals
 -- @section Visuals
 ------------------------------------------------------------------
-
--- @param actualUpdate if true, actually do an update. Otherwise, mark as needUpdate and update in the next frame.
-function RCVotingFrame:Update(actualUpdate)
-	if actualUpdate ~= true then needUpdate = true; return end
+function RCVotingFrame:Update()
+	if updatedThisFrame then needUpdate = true; return end
 	if not self.frame then return end -- No updates when it doesn't exist
 	if not lootTable[session] then return addon:Debug("VotingFrame:Update() without lootTable!!") end -- No updates if lootTable doesn't exist.
+	updatedThisFrame = true
 	self.frame.st:SortData()
 	self.frame.st:SortData() -- It appears that there is a bug in lib-st that only one SortData() does not use the "sortnext" to correct sort the rows.
 	-- update awardString
@@ -485,6 +487,7 @@ function RCVotingFrame:Update(actualUpdate)
 end
 
 updateFrame:SetScript("OnUpdate", function(self, elapsed)
+	updatedThisFrame = false
 	if needUpdate then
 		needUpdate = false
 		RCVotingFrame:Update(true)

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -438,6 +438,7 @@ end
 -- @section Visuals
 ------------------------------------------------------------------
 function RCVotingFrame:Update()
+	needUpdate = false
 	if updatedThisFrame then needUpdate = true; return end
 	if not self.frame then return end -- No updates when it doesn't exist
 	if not lootTable[session] then return addon:Debug("VotingFrame:Update() without lootTable!!") end -- No updates if lootTable doesn't exist.
@@ -489,8 +490,7 @@ end
 updateFrame:SetScript("OnUpdate", function(self, elapsed)
 	updatedThisFrame = false
 	if needUpdate then
-		needUpdate = false
-		RCVotingFrame:Update(true)
+		RCVotingFrame:Update()
 	end
 end)
 

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -33,7 +33,7 @@ local moreInfoData = {}
 local updateFrame = CreateFrame("FRAME") -- to ensure the update operations that does not occur, because it's within min update interval, gets updated eventually
 updateFrame:Hide()
 local needUpdate = false -- Do we need to update votingframe in the next frame?
-local lastUpdateTime = 0 -- Have we updated in the time period of frame?
+local lastUpdateTime = 0 -- What is the value of GetTime() when we last update?
 
 function RCVotingFrame:OnInitialize()
 	-- Contains all the default data needed for the scroll table

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -31,6 +31,7 @@ local GuildRankSort, ResponseSort -- Initialize now to avoid errors
 local defaultScrollTableData = {} -- See below
 local moreInfoData = {}
 local updateFrame = CreateFrame("FRAME") -- to ensure the update operations that does not occur, because it's within min update interval, gets updated eventually
+updateFrame:Hide()
 local needUpdate = false -- Do we need to update votingframe in the next frame?
 local updatedThisFrame = false -- Have we updated in the time period of frame?
 

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -33,7 +33,7 @@ local moreInfoData = {}
 local updateFrame = CreateFrame("FRAME") -- to ensure the update operations that does not occur, because it's within min update interval, gets updated eventually
 updateFrame:Hide()
 local needUpdate = false -- Do we need to update votingframe in the next frame?
-local updatedThisFrame = false -- Have we updated in the time period of frame?
+local lastUpdateTime = 0 -- Have we updated in the time period of frame?
 
 function RCVotingFrame:OnInitialize()
 	-- Contains all the default data needed for the scroll table
@@ -93,7 +93,7 @@ function RCVotingFrame:Hide()
 	self.frame:Hide()
 	updateFrame:Hide()
 	needUpdate = false
-	updatedThisFrame = false
+	lastUpdateTime = 0
 end
 
 function RCVotingFrame:Show()
@@ -103,7 +103,7 @@ function RCVotingFrame:Show()
 		self:SwitchSession(session)
 		updateFrame:Show()
 		needUpdate = false
-		updatedThisFrame = false
+		lastUpdateTime = 0
 	else
 		addon:Print(L["No session running"])
 	end
@@ -440,10 +440,10 @@ end
 ------------------------------------------------------------------
 function RCVotingFrame:Update()
 	needUpdate = false
-	if updatedThisFrame then needUpdate = true; return end
+	if lastUpdateTime == GetTime() then needUpdate = true; return end
 	if not self.frame then return end -- No updates when it doesn't exist
 	if not lootTable[session] then return addon:Debug("VotingFrame:Update() without lootTable!!") end -- No updates if lootTable doesn't exist.
-	updatedThisFrame = true
+	lastUpdateTime = GetTime()
 	self.frame.st:SortData()
 	self.frame.st:SortData() -- It appears that there is a bug in lib-st that only one SortData() does not use the "sortnext" to correct sort the rows.
 	-- update awardString
@@ -489,8 +489,7 @@ function RCVotingFrame:Update()
 end
 
 updateFrame:SetScript("OnUpdate", function(self, elapsed)
-	updatedThisFrame = false
-	if needUpdate then
+	if needUpdate and lastUpdateTime ~= GetTime() then
 		RCVotingFrame:Update()
 	end
 end)


### PR DESCRIPTION
+ After the most recent Curseforge report, I realize 0.2s update interval is not good, especially when switching session. Therefore, the update rate is changed to every frame.