### PR TITLE
Show item bonus text

### DIFF
--- a/Locale/enUS.lua
+++ b/Locale/enUS.lua
@@ -382,6 +382,7 @@ L["Skins"] = true
 L["skins_description"] = "Select one of the default skins or create your own. Note this is purely aesthetic. Open the version checker to see the results right away ('/rc version')."
 L["Something went wrong :'("] = true
 L["Something went wrong during syncing, please try again."] = true
+L["Socket"] = true
 L["Sort Items"] = true
 L["sort_items_desc"] = "Sort sessions by item type and item level."
 L["Standard .csv output."] = true

--- a/Modules/lootFrame.lua
+++ b/Modules/lootFrame.lua
@@ -217,7 +217,9 @@ do
 			entry.icon:SetNormalTexture(entry.item.texture or "Interface\\InventoryItems\\WoWUnknownItem01")
 			entry.itemCount:SetText(#entry.item.sessions > 1 and #entry.item.sessions or "")
 			local typeText = addon:GetItemTypeText(item.link, item.subType, item.equipLoc, item.typeID, item.subTypeID, item.classes, item.isTier, item.isRelic)
-			entry.itemLvl:SetText(addon:GetItemLevelText(entry.item.ilvl, entry.item.isTier).."  |cff7fffff"..typeText.."|r")
+			local bonusText = addon:GetItemBonusText(item.link, "/")
+			if bonusText ~= "" then bonusText = "/"..bonusText end
+			entry.itemLvl:SetText(addon:GetItemLevelText(entry.item.ilvl, entry.item.isTier)..bonusText.."  |cff7fffff"..typeText.."|r")
 			if entry.item.note then
 				entry.noteButton:SetNormalTexture("Interface\\Buttons\\UI-GuildButton-PublicNote-Up")
 			else

--- a/Modules/sessionFrame.lua
+++ b/Modules/sessionFrame.lua
@@ -82,13 +82,15 @@ function RCSessionFrame:ExtractData(data)
 	self.frame.rows = {}
 	-- And set the new
 	for k,v in ipairs(data) do
+		local bonusText = addon:GetItemBonusText(v.link, "\n ")
+		if bonusText ~= "" then bonusText = "\n "..bonusText end
 		self.frame.rows[k] = {
 			texture = v.texture or nil,
 			link = v.link,
 			cols = {
 				{ DoCellUpdate = self.SetCellDeleteBtn, },
 				{ DoCellUpdate = self.SetCellItemIcon},
-				{ value = " "..(addon:GetItemLevelText(v.ilvl, v.token) or ""), },
+				{ value = " "..(addon:GetItemLevelText(v.ilvl, v.token) or "")..bonusText},
 				{ DoCellUpdate = self.SetCellText },
 			},
 		}

--- a/Modules/sessionFrame.lua
+++ b/Modules/sessionFrame.lua
@@ -24,7 +24,7 @@ function RCSessionFrame:OnInitialize()
 	self.scrollCols = {
 		{ name = "", width = 30}, 				-- remove item, sort by session number.
 		{ name = "", width = ROW_HEIGHT},	-- item icon
-		{ name = "", width = ROW_HEIGHT,}, 	-- item lvl
+		{ name = "", width = 50,}, 	-- item lvl
 		{ name = "", width = 160}, 			-- item link
 	}
 end

--- a/Modules/sessionFrame.lua
+++ b/Modules/sessionFrame.lua
@@ -82,7 +82,7 @@ function RCSessionFrame:ExtractData(data)
 	self.frame.rows = {}
 	-- And set the new
 	for k,v in ipairs(data) do
-		local bonusText = addon:GetItemBonusText(v.link, "\n ")
+		local bonusText = v.link and addon:GetItemBonusText(v.link, "\n ") or ""
 		if bonusText ~= "" then bonusText = "\n "..bonusText end
 		self.frame.rows[k] = {
 			texture = v.texture or nil,

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -518,7 +518,6 @@ function RCVotingFrame:SwitchSession(s)
 	local t = lootTable[s] -- Shortcut
 	self.frame.itemIcon:SetNormalTexture(t.texture)
 	self.frame.itemText:SetText(t.link)
-	self.frame.iState:SetText(self:GetItemStatus(t.link))
 	local bonusText = addon:GetItemBonusText(t.link, "/")
 	if bonusText ~= "" then bonusText = "/"..bonusText end
 	self.frame.itemLvl:SetText(_G.ITEM_LEVEL_ABBR..": "..addon:GetItemLevelText(t.ilvl, t.token)..bonusText)
@@ -697,12 +696,6 @@ function RCVotingFrame:GetFrame()
 	ilvl:SetTextColor(1, 1, 1) -- White
 	ilvl:SetText("")
 	f.itemLvl = ilvl
-
-	local iState = f.content:CreateFontString(nil, "OVERLAY", "GameFontNormal")
-	iState:SetPoint("LEFT", ilvl, "RIGHT", 5, 0)
-	iState:SetTextColor(0,1,0,1) -- Green
-	iState:SetText("")
-	f.iState = iState
 
 	local iType = f.content:CreateFontString(nil, "OVERLAY", "GameFontNormal")
 	iType:SetPoint("TOPLEFT", ilvl, "BOTTOMLEFT", 0, -4)

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -519,7 +519,9 @@ function RCVotingFrame:SwitchSession(s)
 	self.frame.itemIcon:SetNormalTexture(t.texture)
 	self.frame.itemText:SetText(t.link)
 	self.frame.iState:SetText(self:GetItemStatus(t.link))
-	self.frame.itemLvl:SetText(_G.ITEM_LEVEL_ABBR..": "..addon:GetItemLevelText(t.ilvl, t.token))
+	local bonusText = addon:GetItemBonusText(t.link, "/")
+	if bonusText ~= "" then bonusText = "/"..bonusText end
+	self.frame.itemLvl:SetText(_G.ITEM_LEVEL_ABBR..": "..addon:GetItemLevelText(t.ilvl, t.token)..bonusText)
 	-- Set a proper item type text
 
 	self.frame.itemType:SetText(addon:GetItemTypeText(t.link, t.subType, t.equipLoc, t.typeID, t.subTypeID, t.classes, t.token, t.relic))

--- a/core.lua
+++ b/core.lua
@@ -2643,7 +2643,7 @@ function RCLootCouncil:GetItemBonusText(link, delimiter)
 		if text ~= "" then text = text..delimiter end
 		text = text.._G.ITEM_MOD_CR_SPEED_SHORT
 	end
-	if itemStatsRet["ITEM_MOD_CR_STURDINESS_SHORT"] then
+	if itemStatsRet["ITEM_MOD_CR_STURDINESS_SHORT"] then -- Indestructible
 		if text ~= "" then text = text..delimiter end
 		text = text.._G.ITEM_MOD_CR_STURDINESS_SHORT
 	end

--- a/core.lua
+++ b/core.lua
@@ -2629,7 +2629,9 @@ end
 local itemStatsRet = {}
 -- Get item bonus text (socket, leech, etc)
 -- Item needs to be cached.
-function RCLootCouncil:GetItemBonusText(link, delimiter)
+function RCLootCouncil:GetItemBonusText(item, delimiter)
+	local link = select(2, GetItemInfo(item))
+	if not link then return "" end
 	if not delimiter then delimiter = "/" end
 	wipe(itemStatsRet)
 	GetItemStats(link, itemStatsRet)

--- a/core.lua
+++ b/core.lua
@@ -2616,6 +2616,41 @@ function RCLootCouncil:GetItemLevelText(ilvl, token)
 	end
 end
 
+local itemStatsRet = {}
+-- Get item bonus text (socket, leech, etc)
+-- Item needs to be cached.
+function RCLootCouncil:GetItemBonusText(link, delimiter)
+	if not delimiter then delimiter = "/" end
+	wipe(itemStatsRet)
+	GetItemStats(link, itemStatsRet)
+	local text = ""
+	for k, _ in pairs(itemStatsRet) do
+		if k:find("SOCKET") then
+			text = L["Socket"]
+			break
+		end
+	end
+
+	if itemStatsRet["ITEM_MOD_CR_AVOIDANCE_SHORT"] then
+		if text ~= "" then text = text..delimiter end
+		text = text.._G.ITEM_MOD_CR_AVOIDANCE_SHORT
+	end
+	if itemStatsRet["ITEM_MOD_CR_LIFESTEAL_SHORT"] then
+		if text ~= "" then text = text..delimiter end
+		text = text.._G.ITEM_MOD_CR_LIFESTEAL_SHORT
+	end
+	if itemStatsRet["ITEM_MOD_CR_MULTISTRIKE_SHORT"] then
+		if text ~= "" then text = text..delimiter end
+		text = text.._G.ITEM_MOD_CR_MULTISTRIKE_SHORT
+	end
+	if itemStatsRet["ITEM_MOD_CR_SPEED_SHORT"] then
+		if text ~= "" then text = text..delimiter end
+		text = text.._G.ITEM_MOD_CR_SPEED_SHORT
+	end
+
+	return text
+end
+
 -- @return a text of the link explaining its type. For example, "Fel Artifact Relic", "Chest, Mail"
 function RCLootCouncil:GetItemTypeText(link, subType, equipLoc, typeID, subTypeID, classesFlag, tokenSlot, relicType)
 	local id = self:GetItemIDFromLink(link)

--- a/core.lua
+++ b/core.lua
@@ -2639,13 +2639,13 @@ function RCLootCouncil:GetItemBonusText(link, delimiter)
 		if text ~= "" then text = text..delimiter end
 		text = text.._G.ITEM_MOD_CR_LIFESTEAL_SHORT
 	end
-	if itemStatsRet["ITEM_MOD_CR_MULTISTRIKE_SHORT"] then
-		if text ~= "" then text = text..delimiter end
-		text = text.._G.ITEM_MOD_CR_MULTISTRIKE_SHORT
-	end
 	if itemStatsRet["ITEM_MOD_CR_SPEED_SHORT"] then
 		if text ~= "" then text = text..delimiter end
 		text = text.._G.ITEM_MOD_CR_SPEED_SHORT
+	end
+	if itemStatsRet["ITEM_MOD_CR_STURDINESS_SHORT"] then
+		if text ~= "" then text = text..delimiter end
+		text = text.._G.ITEM_MOD_CR_STURDINESS_SHORT
 	end
 
 	return text

--- a/core.lua
+++ b/core.lua
@@ -744,6 +744,16 @@ function RCLootCouncil:OnCommReceived(prefix, serializedMsg, distri, sender)
 						return self:Debug("Sent 'DISABLED' response to", sender)
 					end
 
+					-- Cache items
+					local cached = true
+					for k, v in ipairs(lootTable) do
+						if not GetItemInfo(v.link) then cached = false end
+					end
+					if not cached then
+						-- Note: Dont print debug log here. It is spamming.
+						return self:ScheduleTimer("OnCommReceived", 0, prefix, serializedMsg, distri, sender)
+					end
+
 					self:PrepareLootTable(lootTable)
 
 					-- v2.0.1: It seems people somehow receives mldb without numButtons, so check for it aswell.

--- a/core.lua
+++ b/core.lua
@@ -2629,9 +2629,7 @@ end
 local itemStatsRet = {}
 -- Get item bonus text (socket, leech, etc)
 -- Item needs to be cached.
-function RCLootCouncil:GetItemBonusText(item, delimiter)
-	local link = select(2, GetItemInfo(item))
-	if not link then return "" end
+function RCLootCouncil:GetItemBonusText(link, delimiter)
 	if not delimiter then delimiter = "/" end
 	wipe(itemStatsRet)
 	GetItemStats(link, itemStatsRet)


### PR DESCRIPTION
+ The item bonus text(socket/leech/avoidance/speed/indestructible) is now shown in session frame, loot frame and the voting frame.
![wowscrnshot_010118_204501](https://user-images.githubusercontent.com/30888549/34474520-ef6845b4-ef34-11e7-92e1-d50fb25d105d.jpg)
![wowscrnshot_010118_204603](https://user-images.githubusercontent.com/30888549/34474527-fefc5cfe-ef34-11e7-9795-9b11ef8d9e81.jpg)
+ The item state text in the voting frame (green text such as "Mythic Warforged") is removed. One reason is that the item state text is too far right when item bonus is shown with the ilvl. The other reason is that item state is not sth really needed. Everyone can know whether an item is warforged/titanforged according to its ilvl.
+ I have used this PR as ML for two weeks without a problem.