### PR TITLE
Send Transmog info

### DIFF
--- a/Locale/enUS.lua
+++ b/Locale/enUS.lua
@@ -259,6 +259,7 @@ L["ml_sees_voting_desc"] = "Allows the Master Looter to see who's voting for who
 L["Modules"] = true
 L["module_tVersion_outdated_msg"] = "Newest module %s test version is: %s"
 L["module_version_outdated_msg"] = "The module %s version %s is outdated. Newer version is %s."
+L["Mog"] = true
 L["More Info"] = true
 L["more_info_desc"] = "Select how many of your responses you want to see the latest awarded items for. E.g. selecting 2 will (with default settings) show the latest awarded Mainspec and Offspec items, along with how long ago they were awarded."
 L["Multi Vote"] = true

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -1104,17 +1104,17 @@ function RCVotingFrame.SetCellMog(rowFrame, frame, data, cols, row, realrow, col
 
 		if mog then -- Mog collected
 			frame.text:SetText("|TInterface/RAIDFRAME/ReadyCheck-Ready:0:0|t")
-			frame:SetScript("OnEnter", function() addon:CreateTooltip(_G.APPEARANCE_LABEL, _G.COLLECTED) end)
+			frame:SetScript("OnEnter", function() addon:CreateTooltip(_G.APPEARANCE_LABEL, "|cff00ff00".._G.COLLECTED.."|r") end)
 			frame:SetScript("OnLeave", function() addon:HideTooltip() end)
 			data[realrow].cols[column].value = 3 -- Set value for sorting compability
 		elseif mog == nil then -- We don't know
 			frame.text:SetText("|TInterface/RAIDFRAME/ReadyCheck-Waiting:0:0|t")
-			frame:SetScript("OnEnter", function() addon:CreateTooltip(_G.APPEARANCE_LABEL, _G.UNKNOWN) end)
+			frame:SetScript("OnEnter", function() addon:CreateTooltip(_G.APPEARANCE_LABEL, "|cffffff00".._G.UNKNOWN.."|r") end)
 			frame:SetScript("OnLeave", function() addon:HideTooltip() end)
 			data[realrow].cols[column].value = 2 -- Set value for sorting compability
 		else -- Mog not collected
 			frame.text:SetText("|TInterface/RAIDFRAME/ReadyCheck-NotReady:0:0|t")
-			frame:SetScript("OnEnter", function() addon:CreateTooltip(_G.APPEARANCE_LABEL, _G.NOT_COLLECTED) end)
+			frame:SetScript("OnEnter", function() addon:CreateTooltip(_G.APPEARANCE_LABEL, "|cffff0000".._G.NOT_COLLECTED.."|r") end)
 			frame:SetScript("OnLeave", function() addon:HideTooltip() end)
 			data[realrow].cols[column].value = 1 -- Set value for sorting compability
 		end

--- a/core.lua
+++ b/core.lua
@@ -1598,9 +1598,12 @@ function RCLootCouncil:GetItemClassesAllowedFlag(item)
 	return 0xffffffff -- The item works for all classes
 end
 
+-- If the item is dressable, Return true if the appearance of the item has been collected, false otherwise
+-- If the item is not dressable, return nil.
 function RCLootCouncil:IsAppearanceCollected(item)
 	if not item then return end
 	if not GetItemInfo(item) then return end
+	if not IsDressableItem(item) then return end
 	tooltipForParsing:SetOwner(UIParent, "ANCHOR_NONE") -- This lines clear the current content of tooltip and set its position off-screen
 	tooltipForParsing:SetHyperlink(item) -- Set the tooltip content and show it, should hide the tooltip before function ends
 

--- a/core.lua
+++ b/core.lua
@@ -1598,6 +1598,26 @@ function RCLootCouncil:GetItemClassesAllowedFlag(item)
 	return 0xffffffff -- The item works for all classes
 end
 
+function RCLootCouncil:IsAppearanceCollected(item)
+	if not item then return end
+	if not GetItemInfo(item) then return end
+	tooltipForParsing:SetOwner(UIParent, "ANCHOR_NONE") -- This lines clear the current content of tooltip and set its position off-screen
+	tooltipForParsing:SetHyperlink(item) -- Set the tooltip content and show it, should hide the tooltip before function ends
+
+	for i = 1, tooltipForParsing:NumLines() or 0 do
+		local line = getglobal(tooltipForParsing:GetName()..'TextLeft' .. i)
+		if line and line.GetText then
+			local text = line:GetText() or ""
+			if text == TRANSMOGRIFY_TOOLTIP_APPEARANCE_UNKNOWN then
+				return false
+			end
+		end
+	end
+
+	tooltipForParsing:Hide()
+	return true
+end
+
 -- strings contains plural/singular rule such as "%d |4ora:ore;"
 -- For example, CompleteFormatSimpleStringWithPluralRule("%d |4ora:ore;", 2) returns "2 ore"
 -- Does not work for long string such as "%d |4jour:jours;, %d |4heure:heures;, %d |4minute:minutes;, %d |4seconde:secondes;"

--- a/core.lua
+++ b/core.lua
@@ -1378,6 +1378,7 @@ function RCLootCouncil:SendResponse(target, session, response, isTier, isRelic, 
 			isRelic = isRelic or nil,
 			specID = sendSpecID and playersData.specID or nil,
 			roll = roll,
+			mog = self:IsAppearanceCollected(link),
 		})
 end
 


### PR DESCRIPTION
See also issue #149 

1. I don't think this feature should be put in EU, because it happens very frequently that I need to know the transmog info so an non-upgrade piece for the raid will not be wasted.
  + I have a "Transmog" button for the raid. But most people simply clicks pass if they don't need the item, because some people don't actually care about the transmog collection. But as a ML, I don't want an item simply get wasted and I don't want to spend time asking people if anyone possibly doesn't have the appearance.
  + There is no way to know this in-game without asking the raider. There is always some other way to obtain the data of any current feature in EU, including bonus loot (by raid chat, though not 100% reliable), RCScore (by Details/Skada/Recount), etc).
   + > It's relatively simple for a guild to require people to install several addons if they so desire.
   + ^ Although it's true for some people, it's very inconvenient to put some very useful features in a plugin of the addon. And don't expect people to be smart enough to install all required addons. More addons required, less likely. It adds another complexity to download and active the plugin, and lots of people will have no idea of the useful feature in the plugin because it is not in the core of the addon. Use DBM as an example. Currently DBM consists several plugins, including AntorusBurningThrone, Argus, BrokenIsles, Brawlers, etc. Each of these has its own TOC file and can be released as a separate plugin on Curseforge. However, DBM author packs all plugins relevant to the current expansion under the main addon DBM. Imagine all those plugins are released separated, it will be very painful, especially for the new-comers of the game. BigWigs does the same thing. RCLootCouncil is similar to BigWigs and DBM that addon communication is required, therefore addon compatibility between raiders is very important. More steps needed to properly configure the addon, less likely it works. Therefore, I really don't like the existence of Extra Utilities right now.
  + I know combine EU into core takes more memory and CPU, but it can be easily solved by adding settings into RC to enable/disable feature. Unlike EPGP module, EU has nothing major and can be easily combined into the core. (Why DBM still has TrialofValor/EmeraldNightmare modules in the core? Because it is more painful to have no DBM when you do need it and those modules don't take CPU (loaded on demand))
  + Reasons that EPGP module must be standalone and cant be combined into core.
    1. Much large and complex (240KB, vs EU 60KB, code+locale, no lib). For some features of EPGP modules, I need long text to explain how it works.
    2. EPGP modules is never useful to a guild that does not use EPGP as loot rule.
    3. You, evil_morfar, don't write the EPGP module.
  + ^ The above doesn't happen in EU
  + Reasons why TradeSkillMaster releases all its plugin separately. Currently, TradeSkillMaster is designed for advanced players that it requires player to watch lots of video/stream/Wki to make money out of it. This addon currently not designed to be simple to new players. But RC should be simple to new people into the game.


2. I would like to move BonusRoll column from EU into core, because this is very very important for the loot decision, and this is true for any guild, casual or hardcore, unlike Pawn score, or #sockets equipped.
  + I hope the feature will be improve some time to also show if:
    1. The bonus cant be done because there is no more currency. （cross symbol?）
    2. The bonus roll is canceled. The raider clicks No. (stop symbol?)
    3. The bonus roll is pending. The raider is still making his decision. (funnel symbol?)

3. Now it's time to talk about how this PR works.
+ Raider sends if the he has collected the appearance of the item being rolled to the ML.
+ ML shows the info in the Mog column in the voting frame.
   1. If the item has no appearance (Artifact relic, neck, ring, trinket), show nothing.
   2. If the item should be autopassed by the candidate, show nothing, because the appearance cannot be added to the candidate's collection even if he receives the item.
   3. Otherwise, if the candidate has collected its appearance, show green check symbol.
   4. Otherwise, if the candidate has not collected its appearance, show red cross symbol.
   5. Otherwise, if we don't know (because candidate hasn't installed the new version of RC), show question mark symbol.
   6. When ML mouseover thoses symbols, it shows "Apperance collected", "Apperance not collected" or "Apperance unknown"

4. Current problems
+ Nothing send and shown for the tier tokens. I may implement in the future when I find an easy way to generate hardcode appearance data for tier tokens.
+ It could be little bit confusing that "Appearance collected" is displayed as green symbol. Because normally in RCLootCouncil green means you need the item, which is contradict to "Appearance Collected". Therefore, I add the tooltip to clarify this.