### PR TITLE
Updates for TBC Classic

### DIFF
--- a/Libs/AceAddon-3.0/AceAddon-3.0.lua
+++ b/Libs/AceAddon-3.0/AceAddon-3.0.lua
@@ -6,31 +6,31 @@
 -- * **OnEnable** which gets called during the PLAYER_LOGIN event, when most of the data provided by the game is already present.
 -- * **OnDisable**, which is only called when your addon is manually being disabled.
 -- @usage
--- -- A small (but complete) addon, that doesn't do anything, 
+-- -- A small (but complete) addon, that doesn't do anything,
 -- -- but shows usage of the callbacks.
 -- local MyAddon = LibStub("AceAddon-3.0"):NewAddon("MyAddon")
--- 
+--
 -- function MyAddon:OnInitialize()
---   -- do init tasks here, like loading the Saved Variables, 
+--   -- do init tasks here, like loading the Saved Variables,
 --   -- or setting up slash commands.
 -- end
--- 
+--
 -- function MyAddon:OnEnable()
 --   -- Do more initialization here, that really enables the use of your addon.
---   -- Register Events, Hook functions, Create Frames, Get information from 
+--   -- Register Events, Hook functions, Create Frames, Get information from
 --   -- the game that wasn't available in OnInitialize
 -- end
 --
 -- function MyAddon:OnDisable()
 --   -- Unhook, Unregister Events, Hide frames that you created.
---   -- You would probably only use an OnDisable if you want to 
+--   -- You would probably only use an OnDisable if you want to
 --   -- build a "standby" mode, or be able to toggle modules on/off.
 -- end
 -- @class file
 -- @name AceAddon-3.0.lua
--- @release $Id: AceAddon-3.0.lua 1184 2018-07-21 14:13:14Z nevcairiel $
+-- @release $Id: AceAddon-3.0.lua 1238 2020-08-28 16:18:42Z nevcairiel $
 
-local MAJOR, MINOR = "AceAddon-3.0", 12
+local MAJOR, MINOR = "AceAddon-3.0", 13
 local AceAddon, oldminor = LibStub:NewLibrary(MAJOR, MINOR)
 
 if not AceAddon then return end -- No Upgrade needed.
@@ -75,7 +75,7 @@ end
 local Enable, Disable, EnableModule, DisableModule, Embed, NewModule, GetModule, GetName, SetDefaultModuleState, SetDefaultModuleLibraries, SetEnabledState, SetDefaultModulePrototype
 
 -- used in the addon metatable
-local function addontostring( self ) return self.name end 
+local function addontostring( self ) return self.name end
 
 -- Check if the addon is queued for initialization
 local function queuedForInitialization(addon)
@@ -88,14 +88,14 @@ local function queuedForInitialization(addon)
 end
 
 --- Create a new AceAddon-3.0 addon.
--- Any libraries you specified will be embeded, and the addon will be scheduled for 
+-- Any libraries you specified will be embeded, and the addon will be scheduled for
 -- its OnInitialize and OnEnable callbacks.
 -- The final addon object, with all libraries embeded, will be returned.
 -- @paramsig [object ,]name[, lib, ...]
 -- @param object Table to use as a base for the addon (optional)
 -- @param name Name of the addon object to create
 -- @param lib List of libraries to embed into the addon
--- @usage 
+-- @usage
 -- -- Create a simple addon object
 -- MyAddon = LibStub("AceAddon-3.0"):NewAddon("MyAddon", "AceEvent-3.0")
 --
@@ -115,10 +115,10 @@ function AceAddon:NewAddon(objectorname, ...)
 	if type(name)~="string" then
 		error(("Usage: NewAddon([object,] name, [lib, lib, lib, ...]): 'name' - string expected got '%s'."):format(type(name)), 2)
 	end
-	if self.addons[name] then 
+	if self.addons[name] then
 		error(("Usage: NewAddon([object,] name, [lib, lib, lib, ...]): 'name' - Addon '%s' already exists."):format(name), 2)
 	end
-	
+
 	object = object or {}
 	object.name = name
 
@@ -128,7 +128,7 @@ function AceAddon:NewAddon(objectorname, ...)
 		for k, v in pairs(oldmeta) do addonmeta[k] = v end
 	end
 	addonmeta.__tostring = addontostring
-	
+
 	setmetatable( object, addonmeta )
 	self.addons[name] = object
 	object.modules = {}
@@ -136,7 +136,7 @@ function AceAddon:NewAddon(objectorname, ...)
 	object.defaultModuleLibraries = {}
 	Embed( object ) -- embed NewModule, GetModule methods
 	self:EmbedLibraries(object, select(i,...))
-	
+
 	-- add to queue of addons to be initialized upon ADDON_LOADED
 	tinsert(self.initializequeue, object)
 	return object
@@ -147,7 +147,7 @@ end
 -- Throws an error if the addon object cannot be found (except if silent is set).
 -- @param name unique name of the addon object
 -- @param silent if true, the addon is optional, silently return nil if its not found
--- @usage 
+-- @usage
 -- -- Get the Addon
 -- MyAddon = LibStub("AceAddon-3.0"):GetAddon("MyAddon")
 function AceAddon:GetAddon(name, silent)
@@ -202,7 +202,7 @@ end
 -- @paramsig name[, silent]
 -- @param name unique name of the module
 -- @param silent if true, the module is optional, silently return nil if its not found (optional)
--- @usage 
+-- @usage
 -- -- Get the Addon
 -- MyAddon = LibStub("AceAddon-3.0"):GetAddon("MyAddon")
 -- -- Get the Module
@@ -225,23 +225,23 @@ local function IsModuleTrue(self) return true end
 -- @param name unique name of the module
 -- @param prototype object to derive this module from, methods and values from this table will be mixed into the module (optional)
 -- @param lib List of libraries to embed into the addon
--- @usage 
+-- @usage
 -- -- Create a module with some embeded libraries
 -- MyModule = MyAddon:NewModule("MyModule", "AceEvent-3.0", "AceHook-3.0")
--- 
+--
 -- -- Create a module with a prototype
 -- local prototype = { OnEnable = function(self) print("OnEnable called!") end }
 -- MyModule = MyAddon:NewModule("MyModule", prototype, "AceEvent-3.0", "AceHook-3.0")
 function NewModule(self, name, prototype, ...)
 	if type(name) ~= "string" then error(("Usage: NewModule(name, [prototype, [lib, lib, lib, ...]): 'name' - string expected got '%s'."):format(type(name)), 2) end
 	if type(prototype) ~= "string" and type(prototype) ~= "table" and type(prototype) ~= "nil" then error(("Usage: NewModule(name, [prototype, [lib, lib, lib, ...]): 'prototype' - table (prototype), string (lib) or nil expected got '%s'."):format(type(prototype)), 2) end
-	
+
 	if self.modules[name] then error(("Usage: NewModule(name, [prototype, [lib, lib, lib, ...]): 'name' - Module '%s' already exists."):format(name), 2) end
-	
+
 	-- modules are basically addons. We treat them as such. They will be added to the initializequeue properly as well.
 	-- NewModule can only be called after the parent addon is present thus the modules will be initialized after their parent is.
 	local module = AceAddon:NewAddon(fmt("%s_%s", self.name or tostring(self), name))
-	
+
 	module.IsModule = IsModuleTrue
 	module:SetEnabledState(self.defaultModuleState)
 	module.moduleName = name
@@ -256,24 +256,24 @@ function NewModule(self, name, prototype, ...)
 	if not prototype or type(prototype) == "string" then
 		prototype = self.defaultModulePrototype or nil
 	end
-	
+
 	if type(prototype) == "table" then
 		local mt = getmetatable(module)
 		mt.__index = prototype
 		setmetatable(module, mt)  -- More of a Base class type feel.
 	end
-	
+
 	safecall(self.OnModuleCreated, self, module) -- Was in Ace2 and I think it could be a cool thing to have handy.
 	self.modules[name] = module
 	tinsert(self.orderedModules, module)
-	
+
 	return module
 end
 
 --- Returns the real name of the addon or module, without any prefix.
 -- @name //addon//:GetName
--- @paramsig 
--- @usage 
+-- @paramsig
+-- @usage
 -- print(MyAddon:GetName())
 -- -- prints "MyAddon"
 function GetName(self)
@@ -285,8 +285,8 @@ end
 -- and enabling all modules of the addon (unless explicitly disabled).\\
 -- :Enable() also sets the internal `enableState` variable to true
 -- @name //addon//:Enable
--- @paramsig 
--- @usage 
+-- @paramsig
+-- @usage
 -- -- Enable MyModule
 -- MyAddon = LibStub("AceAddon-3.0"):GetAddon("MyAddon")
 -- MyModule = MyAddon:GetModule("MyModule")
@@ -306,8 +306,8 @@ end
 -- and disabling all modules of the addon.\\
 -- :Disable() also sets the internal `enableState` variable to false
 -- @name //addon//:Disable
--- @paramsig 
--- @usage 
+-- @paramsig
+-- @usage
 -- -- Disable MyAddon
 -- MyAddon = LibStub("AceAddon-3.0"):GetAddon("MyAddon")
 -- MyAddon:Disable()
@@ -320,7 +320,7 @@ end
 -- Short-hand function that retrieves the module via `:GetModule` and calls `:Enable` on the module object.
 -- @name //addon//:EnableModule
 -- @paramsig name
--- @usage 
+-- @usage
 -- -- Enable MyModule using :GetModule
 -- MyAddon = LibStub("AceAddon-3.0"):GetAddon("MyAddon")
 -- MyModule = MyAddon:GetModule("MyModule")
@@ -338,7 +338,7 @@ end
 -- Short-hand function that retrieves the module via `:GetModule` and calls `:Disable` on the module object.
 -- @name //addon//:DisableModule
 -- @paramsig name
--- @usage 
+-- @usage
 -- -- Disable MyModule using :GetModule
 -- MyAddon = LibStub("AceAddon-3.0"):GetAddon("MyAddon")
 -- MyModule = MyAddon:GetModule("MyModule")
@@ -357,7 +357,7 @@ end
 -- @name //addon//:SetDefaultModuleLibraries
 -- @paramsig lib[, lib, ...]
 -- @param lib List of libraries to embed into the addon
--- @usage 
+-- @usage
 -- -- Create the addon object
 -- MyAddon = LibStub("AceAddon-3.0"):NewAddon("MyAddon")
 -- -- Configure default libraries for modules (all modules need AceEvent-3.0)
@@ -376,7 +376,7 @@ end
 -- @name //addon//:SetDefaultModuleState
 -- @paramsig state
 -- @param state Default state for new modules, true for enabled, false for disabled
--- @usage 
+-- @usage
 -- -- Create the addon object
 -- MyAddon = LibStub("AceAddon-3.0"):NewAddon("MyAddon")
 -- -- Set the default state to "disabled"
@@ -396,7 +396,7 @@ end
 -- @name //addon//:SetDefaultModulePrototype
 -- @paramsig prototype
 -- @param prototype Default prototype for the new modules (table)
--- @usage 
+-- @usage
 -- -- Define a prototype
 -- local prototype = { OnEnable = function(self) print("OnEnable called!") end }
 -- -- Set the default prototype
@@ -428,8 +428,8 @@ end
 
 --- Return an iterator of all modules associated to the addon.
 -- @name //addon//:IterateModules
--- @paramsig 
--- @usage 
+-- @paramsig
+-- @usage
 -- -- Enable all modules
 -- for name, module in MyAddon:IterateModules() do
 --    module:Enable()
@@ -438,13 +438,13 @@ local function IterateModules(self) return pairs(self.modules) end
 
 -- Returns an iterator of all embeds in the addon
 -- @name //addon//:IterateEmbeds
--- @paramsig 
+-- @paramsig
 local function IterateEmbeds(self) return pairs(AceAddon.embeds[self]) end
 
 --- Query the enabledState of an addon.
 -- @name //addon//:IsEnabled
--- @paramsig 
--- @usage 
+-- @paramsig
+-- @usage
 -- if MyAddon:IsEnabled() then
 --     MyAddon:Disable()
 -- end
@@ -489,20 +489,20 @@ end
 
 -- - Initialize the addon after creation.
 -- This function is only used internally during the ADDON_LOADED event
--- It will call the **OnInitialize** function on the addon object (if present), 
+-- It will call the **OnInitialize** function on the addon object (if present),
 -- and the **OnEmbedInitialize** function on all embeded libraries.
--- 
+--
 -- **Note:** Do not call this function manually, unless you're absolutely sure that you know what you are doing.
 -- @param addon addon object to intialize
 function AceAddon:InitializeAddon(addon)
 	safecall(addon.OnInitialize, addon)
-	
+
 	local embeds = self.embeds[addon]
 	for i = 1, #embeds do
 		local lib = LibStub:GetLibrary(embeds[i], true)
 		if lib then safecall(lib.OnEmbedInitialize, lib, addon) end
 	end
-	
+
 	-- we don't call InitializeAddon on modules specifically, this is handled
 	-- from the event handler and only done _once_
 end
@@ -510,7 +510,7 @@ end
 -- - Enable the addon after creation.
 -- Note: This function is only used internally during the PLAYER_LOGIN event, or during ADDON_LOADED,
 -- if IsLoggedIn() already returns true at that point, e.g. for LoD Addons.
--- It will call the **OnEnable** function on the addon object (if present), 
+-- It will call the **OnEnable** function on the addon object (if present),
 -- and the **OnEmbedEnable** function on all embeded libraries.\\
 -- This function does not toggle the enable state of the addon itself, and will return early if the addon is disabled.
 --
@@ -520,12 +520,12 @@ end
 function AceAddon:EnableAddon(addon)
 	if type(addon) == "string" then addon = AceAddon:GetAddon(addon) end
 	if self.statuses[addon.name] or not addon.enabledState then return false end
-	
+
 	-- set the statuses first, before calling the OnEnable. this allows for Disabling of the addon in OnEnable.
 	self.statuses[addon.name] = true
-	
+
 	safecall(addon.OnEnable, addon)
-	
+
 	-- make sure we're still enabled before continueing
 	if self.statuses[addon.name] then
 		local embeds = self.embeds[addon]
@@ -533,7 +533,7 @@ function AceAddon:EnableAddon(addon)
 			local lib = LibStub:GetLibrary(embeds[i], true)
 			if lib then safecall(lib.OnEmbedEnable, lib, addon) end
 		end
-	
+
 		-- enable possible modules.
 		local modules = addon.orderedModules
 		for i = 1, #modules do
@@ -545,24 +545,24 @@ end
 
 -- - Disable the addon
 -- Note: This function is only used internally.
--- It will call the **OnDisable** function on the addon object (if present), 
+-- It will call the **OnDisable** function on the addon object (if present),
 -- and the **OnEmbedDisable** function on all embeded libraries.\\
 -- This function does not toggle the enable state of the addon itself, and will return early if the addon is still enabled.
 --
--- **Note:** Do not call this function manually, unless you're absolutely sure that you know what you are doing. 
+-- **Note:** Do not call this function manually, unless you're absolutely sure that you know what you are doing.
 -- Use :Disable on the addon itself instead.
 -- @param addon addon object to enable
 function AceAddon:DisableAddon(addon)
 	if type(addon) == "string" then addon = AceAddon:GetAddon(addon) end
 	if not self.statuses[addon.name] then return false end
-	
+
 	-- set statuses first before calling OnDisable, this allows for aborting the disable in OnDisable.
 	self.statuses[addon.name] = false
-	
+
 	safecall( addon.OnDisable, addon )
-	
+
 	-- make sure we're still disabling...
-	if not self.statuses[addon.name] then 
+	if not self.statuses[addon.name] then
 		local embeds = self.embeds[addon]
 		for i = 1, #embeds do
 			local lib = LibStub:GetLibrary(embeds[i], true)
@@ -574,12 +574,12 @@ function AceAddon:DisableAddon(addon)
 			self:DisableAddon(modules[i])
 		end
 	end
-	
+
 	return not self.statuses[addon.name] -- return true if we're disabled
 end
 
 --- Get an iterator over all registered addons.
--- @usage 
+-- @usage
 -- -- Print a list of all installed AceAddon's
 -- for name, addon in AceAddon:IterateAddons() do
 --   print("Addon: " .. name)
@@ -587,7 +587,7 @@ end
 function AceAddon:IterateAddons() return pairs(self.addons) end
 
 --- Get an iterator over the internal status registry.
--- @usage 
+-- @usage
 -- -- Print a list of all enabled addons
 -- for name, status in AceAddon:IterateAddonStatus() do
 --   if status then
@@ -601,10 +601,20 @@ function AceAddon:IterateAddonStatus() return pairs(self.statuses) end
 function AceAddon:IterateEmbedsOnAddon(addon) return pairs(self.embeds[addon]) end
 function AceAddon:IterateModulesOfAddon(addon) return pairs(addon.modules) end
 
+-- Blizzard AddOns which can load very early in the loading process and mess with Ace3 addon loading
+local BlizzardEarlyLoadAddons = {
+	Blizzard_DebugTools = true,
+	Blizzard_TimeManager = true,
+	Blizzard_BattlefieldMap = true,
+	Blizzard_MapCanvas = true,
+	Blizzard_SharedMapDataProviders = true,
+	Blizzard_CombatLog = true,
+}
+
 -- Event Handling
 local function onEvent(this, event, arg1)
-	-- 2011-08-17 nevcairiel - ignore the load event of Blizzard_DebugTools, so a potential startup error isn't swallowed up
-	if (event == "ADDON_LOADED"  and arg1 ~= "Blizzard_DebugTools") or event == "PLAYER_LOGIN" then
+	-- 2020-08-28 nevcairiel - ignore the load event of Blizzard addons which occur early in the loading process
+	if (event == "ADDON_LOADED"  and (arg1 == nil or not BlizzardEarlyLoadAddons[arg1])) or event == "PLAYER_LOGIN" then
 		-- if a addon loads another addon, recursion could happen here, so we need to validate the table on every iteration
 		while(#AceAddon.initializequeue > 0) do
 			local addon = tremove(AceAddon.initializequeue, 1)
@@ -613,7 +623,7 @@ local function onEvent(this, event, arg1)
 			AceAddon:InitializeAddon(addon)
 			tinsert(AceAddon.enablequeue, addon)
 		end
-		
+
 		if IsLoggedIn() then
 			while(#AceAddon.enablequeue > 0) do
 				local addon = tremove(AceAddon.enablequeue, 1)

--- a/Libs/AceBucket-3.0/AceBucket-3.0.lua
+++ b/Libs/AceBucket-3.0/AceBucket-3.0.lua
@@ -1,28 +1,28 @@
 --- A bucket to catch events in. **AceBucket-3.0** provides throttling of events that fire in bursts and
 -- your addon only needs to know about the full burst.
--- 
+--
 -- This Bucket implementation works as follows:\\
 --   Initially, no schedule is running, and its waiting for the first event to happen.\\
 --   The first event will start the bucket, and get the scheduler running, which will collect all
---   events in the given interval. When that interval is reached, the bucket is pushed to the 
---   callback and a new schedule is started. When a bucket is empty after its interval, the scheduler is 
+--   events in the given interval. When that interval is reached, the bucket is pushed to the
+--   callback and a new schedule is started. When a bucket is empty after its interval, the scheduler is
 --   stopped, and the bucket is only listening for the next event to happen, basically back in its initial state.
--- 
--- In addition, the buckets collect information about the "arg1" argument of the events that fire, and pass those as a 
+--
+-- In addition, the buckets collect information about the "arg1" argument of the events that fire, and pass those as a
 -- table to your callback. This functionality was mostly designed for the UNIT_* events.\\
 -- The table will have the different values of "arg1" as keys, and the number of occurances as their value, e.g.\\
 --   { ["player"] = 2, ["target"] = 1, ["party1"] = 1 }
 --
--- **AceBucket-3.0** can be embeded into your addon, either explicitly by calling AceBucket:Embed(MyAddon) or by 
+-- **AceBucket-3.0** can be embeded into your addon, either explicitly by calling AceBucket:Embed(MyAddon) or by
 -- specifying it as an embeded library in your AceAddon. All functions will be available on your addon object
 -- and can be accessed directly, without having to explicitly call AceBucket itself.\\
 -- It is recommended to embed AceBucket, otherwise you'll have to specify a custom `self` on all calls you
 -- make into AceBucket.
 -- @usage
 -- MyAddon = LibStub("AceAddon-3.0"):NewAddon("BucketExample", "AceBucket-3.0")
--- 
+--
 -- function MyAddon:OnEnable()
---   -- Register a bucket that listens to all the HP related events, 
+--   -- Register a bucket that listens to all the HP related events,
 --   -- and fires once per second
 --   self:RegisterBucketEvent({"UNIT_HEALTH", "UNIT_MAXHEALTH"}, 1, "UpdateHealth")
 -- end
@@ -34,7 +34,7 @@
 -- end
 -- @class file
 -- @name AceBucket-3.0.lua
--- @release $Id: AceBucket-3.0.lua 1185 2018-07-21 14:15:16Z nevcairiel $
+-- @release $Id: AceBucket-3.0.lua 1202 2019-05-15 23:11:22Z nevcairiel $
 
 local MAJOR, MINOR = "AceBucket-3.0", 4
 local AceBucket, oldminor = LibStub:NewLibrary(MAJOR, MINOR)
@@ -79,7 +79,7 @@ end
 -- send the bucket to the callback function and schedule the next FireBucket in interval seconds
 local function FireBucket(bucket)
 	local received = bucket.received
-	
+
 	-- we dont want to fire empty buckets
 	if next(received) ~= nil then
 		local callback = bucket.callback
@@ -88,11 +88,11 @@ local function FireBucket(bucket)
 		else
 			safecall(callback, received)
 		end
-		
+
 		for k in pairs(received) do
 			received[k] = nil
 		end
-		
+
 		-- if the bucket was not empty, schedule another FireBucket in interval seconds
 		bucket.timer = AceTimer.ScheduleTimer(bucket, FireBucket, bucket.interval, bucket)
 	else -- if it was empty, clear the timer and wait for the next event
@@ -101,16 +101,16 @@ local function FireBucket(bucket)
 end
 
 -- BucketHandler ( event, arg1 )
--- 
+--
 -- callback func for AceEvent
 -- stores arg1 in the received table, and schedules the bucket if necessary
 local function BucketHandler(self, event, arg1)
 	if arg1 == nil then
 		arg1 = "nil"
 	end
-	
+
 	self.received[arg1] = (self.received[arg1] or 0) + 1
-	
+
 	-- if we are not scheduled yet, start a timer on the interval for our bucket to be cleared
 	if not self.timer then
 		self.timer = AceTimer.ScheduleTimer(self, FireBucket, self.interval, self)
@@ -125,14 +125,14 @@ end
 -- isMessage(boolean) - register AceEvent Messages instead of game events
 local function RegisterBucket(self, event, interval, callback, isMessage)
 	-- try to fetch the librarys
-	if not AceEvent or not AceTimer then 
+	if not AceEvent or not AceTimer then
 		AceEvent = LibStub:GetLibrary("AceEvent-3.0", true)
 		AceTimer = LibStub:GetLibrary("AceTimer-3.0", true)
 		if not AceEvent or not AceTimer then
 			error(MAJOR .. " requires AceEvent-3.0 and AceTimer-3.0", 3)
 		end
 	end
-	
+
 	if type(event) ~= "string" and type(event) ~= "table" then error("Usage: RegisterBucket(event, interval, callback): 'event' - string or table expected.", 3) end
 	if not callback then
 		if type(event) == "string" then
@@ -144,7 +144,7 @@ local function RegisterBucket(self, event, interval, callback, isMessage)
 	if not tonumber(interval) then error("Usage: RegisterBucket(event, interval, callback): 'interval' - number expected.", 3) end
 	if type(callback) ~= "string" and type(callback) ~= "function" then error("Usage: RegisterBucket(event, interval, callback): 'callback' - string or function or nil expected.", 3) end
 	if type(callback) == "string" and type(self[callback]) ~= "function" then error("Usage: RegisterBucket(event, interval, callback): 'callback' - method not found on target object.", 3) end
-	
+
 	local bucket = next(bucketCache)
 	if bucket then
 		bucketCache[bucket] = nil
@@ -152,9 +152,9 @@ local function RegisterBucket(self, event, interval, callback, isMessage)
 		bucket = { handler = BucketHandler, received = {} }
 	end
 	bucket.object, bucket.callback, bucket.interval = self, callback, tonumber(interval)
-	
+
 	local regFunc = isMessage and AceEvent.RegisterMessage or AceEvent.RegisterEvent
-	
+
 	if type(event) == "table" then
 		for _,e in pairs(event) do
 			regFunc(bucket, e, "handler")
@@ -162,10 +162,10 @@ local function RegisterBucket(self, event, interval, callback, isMessage)
 	else
 		regFunc(bucket, event, "handler")
 	end
-	
+
 	local handle = tostring(bucket)
 	AceBucket.buckets[handle] = bucket
-	
+
 	return handle
 end
 
@@ -177,7 +177,7 @@ end
 -- @usage
 -- MyAddon = LibStub("AceAddon-3.0"):NewAddon("MyAddon", "AceBucket-3.0")
 -- MyAddon:RegisterBucketEvent("BAG_UPDATE", 0.2, "UpdateBags")
--- 
+--
 -- function MyAddon:UpdateBags()
 --   -- do stuff
 -- end
@@ -193,7 +193,7 @@ end
 -- @usage
 -- MyAddon = LibStub("AceAddon-3.0"):NewAddon("MyAddon", "AceBucket-3.0")
 -- MyAddon:RegisterBucketEvent("SomeAddon_InformationMessage", 0.2, "ProcessData")
--- 
+--
 -- function MyAddon:ProcessData()
 --   -- do stuff
 -- end
@@ -208,17 +208,17 @@ function AceBucket:UnregisterBucket(handle)
 	if bucket then
 		AceEvent.UnregisterAllEvents(bucket)
 		AceEvent.UnregisterAllMessages(bucket)
-		
+
 		-- clear any remaining data in the bucket
 		for k in pairs(bucket.received) do
 			bucket.received[k] = nil
 		end
-		
+
 		if bucket.timer then
 			AceTimer.CancelTimer(bucket, bucket.timer)
 			bucket.timer = nil
 		end
-		
+
 		AceBucket.buckets[handle] = nil
 		-- store our bucket in the cache
 		bucketCache[bucket] = true
@@ -240,10 +240,10 @@ end
 -- embedding and embed handling
 local mixins = {
 	"RegisterBucketEvent",
-	"RegisterBucketMessage", 
+	"RegisterBucketMessage",
 	"UnregisterBucket",
 	"UnregisterAllBuckets",
-} 
+}
 
 -- Embeds AceBucket into the target object making the functions from the mixins list available on target:..
 -- @param target target object to embed AceBucket in

--- a/Libs/AceComm-3.0/AceComm-3.0.lua
+++ b/Libs/AceComm-3.0/AceComm-3.0.lua
@@ -2,14 +2,14 @@
 -- It'll automatically split the messages into multiple parts and rebuild them on the receiving end.\\
 -- **ChatThrottleLib** is of course being used to avoid being disconnected by the server.
 --
--- **AceComm-3.0** can be embeded into your addon, either explicitly by calling AceComm:Embed(MyAddon) or by 
+-- **AceComm-3.0** can be embeded into your addon, either explicitly by calling AceComm:Embed(MyAddon) or by
 -- specifying it as an embeded library in your AceAddon. All functions will be available on your addon object
 -- and can be accessed directly, without having to explicitly call AceComm itself.\\
 -- It is recommended to embed AceComm, otherwise you'll have to specify a custom `self` on all calls you
 -- make into AceComm.
 -- @class file
 -- @name AceComm-3.0
--- @release $Id: AceComm-3.0.lua 1174 2018-05-14 17:29:49Z h.leppkes@gmail.com $
+-- @release $Id: AceComm-3.0.lua 1202 2019-05-15 23:11:22Z nevcairiel $
 
 --[[ AceComm-3.0
 
@@ -52,7 +52,7 @@ AceComm.multipart_origprefixes = nil
 AceComm.multipart_reassemblers = nil
 
 -- the multipart message spool: indexed by a combination of sender+distribution+
-AceComm.multipart_spool = AceComm.multipart_spool or {} 
+AceComm.multipart_spool = AceComm.multipart_spool or {}
 
 --- Register for Addon Traffic on a specified prefix
 -- @param prefix A printable character (\032-\255) classification of the message (typically AddonName or AddonNameEvent), max 16 characters
@@ -90,7 +90,7 @@ function AceComm:SendCommMessage(prefix, text, distribution, target, prio, callb
 			type(text)=="string" and
 			type(distribution)=="string" and
 			(target==nil or type(target)=="string" or type(target)=="number") and
-			(prio=="BULK" or prio=="NORMAL" or prio=="ALERT") 
+			(prio=="BULK" or prio=="NORMAL" or prio=="ALERT")
 		) then
 		error('Usage: SendCommMessage(addon, "prefix", "text", "distribution"[, "target"[, "prio"[, callbackFn, callbackarg]]])', 2)
 	end
@@ -105,7 +105,7 @@ function AceComm:SendCommMessage(prefix, text, distribution, target, prio, callb
 			return callbackFn(callbackArg, sent, textlen)
 		end
 	end
-	
+
 	local forceMultipart
 	if match(text, "^[\001-\009]") then -- 4.1+: see if the first character is a control character
 		-- we need to escape the first character with a \004
@@ -150,17 +150,17 @@ do
 	local compost = setmetatable({}, {__mode = "k"})
 	local function new()
 		local t = next(compost)
-		if t then 
+		if t then
 			compost[t]=nil
 			for i=#t,3,-1 do	-- faster than pairs loop. don't even nil out 1/2 since they'll be overwritten
 				t[i]=nil
 			end
 			return t
 		end
-		
+
 		return {}
 	end
-	
+
 	local function lostdatawarning(prefix,sender,where)
 		DEFAULT_CHAT_FRAME:AddMessage(MAJOR..": Warning: lost network data regarding '"..tostring(prefix).."' from '"..tostring(sender).."' (in "..where..")")
 	end
@@ -168,14 +168,14 @@ do
 	function AceComm:OnReceiveMultipartFirst(prefix, message, distribution, sender)
 		local key = prefix.."\t"..distribution.."\t"..sender	-- a unique stream is defined by the prefix + distribution + sender
 		local spool = AceComm.multipart_spool
-		
+
 		--[[
-		if spool[key] then 
+		if spool[key] then
 			lostdatawarning(prefix,sender,"First")
 			-- continue and overwrite
 		end
 		--]]
-		
+
 		spool[key] = message  -- plain string for now
 	end
 
@@ -183,7 +183,7 @@ do
 		local key = prefix.."\t"..distribution.."\t"..sender	-- a unique stream is defined by the prefix + distribution + sender
 		local spool = AceComm.multipart_spool
 		local olddata = spool[key]
-		
+
 		if not olddata then
 			--lostdatawarning(prefix,sender,"Next")
 			return
@@ -204,14 +204,14 @@ do
 		local key = prefix.."\t"..distribution.."\t"..sender	-- a unique stream is defined by the prefix + distribution + sender
 		local spool = AceComm.multipart_spool
 		local olddata = spool[key]
-		
+
 		if not olddata then
 			--lostdatawarning(prefix,sender,"End")
 			return
 		end
 
 		spool[key] = nil
-		
+
 		if type(olddata) == "table" then
 			-- if we've received a "next", the spooled data will be a table for rapid & garbage-free tconcat
 			tinsert(olddata, message)

--- a/Libs/AceComm-3.0/ChatThrottleLib.lua
+++ b/Libs/AceComm-3.0/ChatThrottleLib.lua
@@ -3,7 +3,7 @@
 --
 -- Manages AddOn chat output to keep player from getting kicked off.
 --
--- ChatThrottleLib:SendChatMessage/:SendAddonMessage functions that accept 
+-- ChatThrottleLib:SendChatMessage/:SendAddonMessage functions that accept
 -- a Priority ("BULK", "NORMAL", "ALERT") as well as prefix for SendChatMessage.
 --
 -- Priorities get an equal share of available bandwidth when fully loaded.
@@ -75,7 +75,7 @@ local next = next
 local strlen = string.len
 local GetFramerate = GetFramerate
 local strlower = string.lower
-local unpack,type,pairs,wipe = unpack,type,pairs,wipe
+local unpack,type,pairs,wipe = unpack,type,pairs,table.wipe
 local UnitInRaid,UnitInParty = UnitInRaid,UnitInParty
 
 
@@ -118,7 +118,7 @@ end
 
 
 -----------------------------------------------------------------------
--- Recycling bin for pipes 
+-- Recycling bin for pipes
 -- A pipe is a plain integer-indexed queue of messages
 -- Pipes normally live in Rings of pipes  (3 rings total, one per priority)
 
@@ -169,7 +169,7 @@ end
 -- Initialize queues, set up frame for OnUpdate, etc
 
 
-function ChatThrottleLib:Init()	
+function ChatThrottleLib:Init()
 
 	-- Set up queues
 	if not self.Prio then
@@ -356,8 +356,8 @@ function ChatThrottleLib.OnUpdate(this,delay)
 	-- See how many of our priorities have queued messages (we only have 3, don't worry about the loop)
 	local n = 0
 	for prioname,Prio in pairs(self.Prio) do
-		if Prio.Ring.pos or Prio.avail < 0 then 
-			n = n + 1 
+		if Prio.Ring.pos or Prio.avail < 0 then
+			n = n + 1
 		end
 	end
 

--- a/Libs/AceConfig-3.0/AceConfig-3.0.lua
+++ b/Libs/AceConfig-3.0/AceConfig-3.0.lua
@@ -3,7 +3,7 @@
 -- as well as associate it with a slash command.
 -- @class file
 -- @name AceConfig-3.0
--- @release $Id: AceConfig-3.0.lua 1161 2017-08-12 14:30:16Z funkydude $
+-- @release $Id: AceConfig-3.0.lua 1202 2019-05-15 23:11:22Z nevcairiel $
 
 --[[
 AceConfig-3.0
@@ -45,7 +45,7 @@ local pcall, error, type, pairs = pcall, error, type, pairs
 function AceConfig:RegisterOptionsTable(appName, options, slashcmd)
 	local ok,msg = pcall(cfgreg.RegisterOptionsTable, self, appName, options)
 	if not ok then error(msg, 2) end
-	
+
 	if slashcmd then
 		if type(slashcmd) == "table" then
 			for _,cmd in pairs(slashcmd) do

--- a/Libs/AceConfig-3.0/AceConfigCmd-3.0/AceConfigCmd-3.0.lua
+++ b/Libs/AceConfig-3.0/AceConfigCmd-3.0/AceConfigCmd-3.0.lua
@@ -1,7 +1,7 @@
 --- AceConfigCmd-3.0 handles access to an options table through the "command line" interface via the ChatFrames.
 -- @class file
 -- @name AceConfigCmd-3.0
--- @release $Id: AceConfigCmd-3.0.lua 1161 2017-08-12 14:30:16Z funkydude $
+-- @release $Id: AceConfigCmd-3.0.lua 1202 2019-05-15 23:11:22Z nevcairiel $
 
 --[[
 AceConfigCmd-3.0
@@ -63,7 +63,7 @@ local funcmsg = "expected function or member name"
 
 -- pickfirstset() - picks the first non-nil value and returns it
 
-local function pickfirstset(...)	
+local function pickfirstset(...)
 	for i=1,select("#",...) do
 		if select(i,...)~=nil then
 			return select(i,...)
@@ -120,7 +120,7 @@ local function callfunction(info, tab, methodtype, ...)
 	info.arg = tab.arg
 	info.option = tab
 	info.type = tab.type
-	
+
 	if type(method)=="function" then
 		return method(info, ...)
 	else
@@ -131,7 +131,7 @@ end
 -- do_final() - do the final step (set/execute) along with validation and confirmation
 
 local function do_final(info, inputpos, tab, methodtype, ...)
-	if info.validate then 
+	if info.validate then
 		local res = callmethod(info,inputpos,tab,"validate",...)
 		if type(res)=="string" then
 			usererr(info, inputpos, "'"..strsub(info.input, inputpos).."' - "..res)
@@ -139,7 +139,7 @@ local function do_final(info, inputpos, tab, methodtype, ...)
 		end
 	end
 	-- console ignores .confirm
-	
+
 	callmethod(info,inputpos,tab,methodtype, ...)
 end
 
@@ -152,8 +152,8 @@ local function getparam(info, inputpos, tab, depth, paramname, types, errormsg)
 	if val~=nil then
 		if val==false then
 			val=nil
-		elseif not types[type(val)] then 
-			err(info, inputpos, "'" .. paramname.. "' - "..errormsg) 
+		elseif not types[type(val)] then
+			err(info, inputpos, "'" .. paramname.. "' - "..errormsg)
 		end
 		info[paramname] = val
 		info[paramname.."_at"] = depth
@@ -166,13 +166,13 @@ end
 local dummytable={}
 
 local function iterateargs(tab)
-	if not tab.plugins then 
-		return pairs(tab.args) 
+	if not tab.plugins then
+		return pairs(tab.args)
 	end
-	
+
 	local argtabkey,argtab=next(tab.plugins)
 	local v
-	
+
 	return function(_, k)
 		while argtab do
 			k,v = next(argtab, k)
@@ -206,18 +206,18 @@ local function showhelp(info, inputpos, tab, depth, noHead)
 	if not noHead then
 		print("|cff33ff99"..info.appName.."|r: Arguments to |cffffff78/"..info[0].."|r "..strsub(info.input,1,inputpos-1)..":")
 	end
-	
+
 	local sortTbl = {}	-- [1..n]=name
 	local refTbl = {}   -- [name]=tableref
-	
+
 	for k,v in iterateargs(tab) do
 		if not refTbl[k] then	-- a plugin overriding something in .args
 			tinsert(sortTbl, k)
 			refTbl[k] = v
 		end
 	end
-	
-	tsort(sortTbl, function(one, two) 
+
+	tsort(sortTbl, function(one, two)
 		local o1 = refTbl[one].order or 100
 		local o2 = refTbl[two].order or 100
 		if type(o1) == "function" or type(o1) == "string" then
@@ -240,7 +240,7 @@ local function showhelp(info, inputpos, tab, depth, noHead)
 		if o1==o2 then return tostring(one)<tostring(two) end   -- compare names
 		return o1<o2
 	end)
-	
+
 	for i = 1, #sortTbl do
 		local k = sortTbl[i]
 		local v = refTbl[k]
@@ -327,7 +327,7 @@ local function keybindingValidateFunc(text)
 	return s
 end
 
--- handle() - selfrecursing function that processes input->optiontable 
+-- handle() - selfrecursing function that processes input->optiontable
 -- - depth - starts at 0
 -- - retfalse - return false rather than produce error if a match is not found (used by inlined groups)
 
@@ -346,16 +346,16 @@ local function handle(info, inputpos, tab, depth, retfalse)
 	local oldfunc,oldfunc_at = getparam(info,inputpos,tab,depth,"func",functypes,funcmsg)
 	local oldvalidate,oldvalidate_at = getparam(info,inputpos,tab,depth,"validate",functypes,funcmsg)
 	--local oldconfirm,oldconfirm_at = getparam(info,inputpos,tab,depth,"confirm",functypes,funcmsg)
-	
+
 	-------------------------------------------------------------------
 	-- Act according to .type of this table
-		
+
 	if tab.type=="group" then
 		------------ group --------------------------------------------
-		
+
 		if type(tab.args)~="table" then err(info, inputpos) end
 		if tab.plugins and type(tab.plugins)~="table" then err(info,inputpos) end
-		
+
 		-- grab next arg from input
 		local _,nextpos,arg = (info.input):find(" *([^ ]+) *", inputpos)
 		if not arg then
@@ -363,11 +363,11 @@ local function handle(info, inputpos, tab, depth, retfalse)
 			return
 		end
 		nextpos=nextpos+1
-		
+
 		-- loop .args and try to find a key with a matching name
 		for k,v in iterateargs(tab) do
 			if not(type(k)=="string" and type(v)=="table" and type(v.type)=="string") then err(info,inputpos, "options table child '"..tostring(k).."' is malformed") end
-			
+
 			-- is this child an inline group? if so, traverse into it
 			if v.type=="group" and pickfirstset(v.cmdInline, v.inline, false) then
 				info[depth+1] = k
@@ -383,8 +383,8 @@ local function handle(info, inputpos, tab, depth, retfalse)
 				return handle(info,nextpos,v,depth+1)
 			end
 		end
-			
-		-- no match 
+
+		-- no match
 		if retfalse then
 			-- restore old infotable members and return false to indicate failure
 			info.handler,info.handler_at = oldhandler,oldhandler_at
@@ -395,23 +395,23 @@ local function handle(info, inputpos, tab, depth, retfalse)
 			--info.confirm,info.confirm_at = oldconfirm,oldconfirm_at
 			return false
 		end
-		
+
 		-- couldn't find the command, display error
 		usererr(info, inputpos, "'"..arg.."' - " .. L["unknown argument"])
 		return
 	end
-	
+
 	local str = strsub(info.input,inputpos);
-	
+
 	if tab.type=="execute" then
 		------------ execute --------------------------------------------
 		do_final(info, inputpos, tab, "func")
-		
 
-	
+
+
 	elseif tab.type=="input" then
 		------------ input --------------------------------------------
-		
+
 		local res = true
 		if tab.pattern then
 			if not(type(tab.pattern)=="string") then err(info, inputpos, "'pattern' - expected a string") end
@@ -420,11 +420,11 @@ local function handle(info, inputpos, tab, depth, retfalse)
 				return
 			end
 		end
-		
-		do_final(info, inputpos, tab, "set", str)
-		
 
-	
+		do_final(info, inputpos, tab, "set", str)
+
+
+
 	elseif tab.type=="toggle" then
 		------------ toggle --------------------------------------------
 		local b
@@ -444,7 +444,7 @@ local function handle(info, inputpos, tab, depth, retfalse)
 			else
 				b = not b
 			end
-			
+
 		elseif str==L["on"] then
 			b = true
 		elseif str==L["off"] then
@@ -459,9 +459,9 @@ local function handle(info, inputpos, tab, depth, retfalse)
 			end
 			return
 		end
-		
+
 		do_final(info, inputpos, tab, "set", b)
-		
+
 
 	elseif tab.type=="range" then
 		------------ range --------------------------------------------
@@ -481,21 +481,21 @@ local function handle(info, inputpos, tab, depth, retfalse)
 			usererr(info, inputpos, val.." - "..format(L["must be equal to or lower than %s"], tostring(info.max)) )
 			return
 		end
-		
+
 		do_final(info, inputpos, tab, "set", val)
 
-	
+
 	elseif tab.type=="select" then
 		------------ select ------------------------------------
 		local str = strtrim(strlower(str))
-		
+
 		local values = tab.values
 		if type(values) == "function" or type(values) == "string" then
 			info.values = values
 			values = callmethod(info, inputpos, tab, "values")
 			info.values = nil
 		end
-		
+
 		if str == "" then
 			local b = callmethod(info, inputpos, tab, "get")
 			local fmt = "|cffffff78- [%s]|r %s"
@@ -512,7 +512,7 @@ local function handle(info, inputpos, tab, depth, retfalse)
 		end
 
 		local ok
-		for k,v in pairs(values) do 
+		for k,v in pairs(values) do
 			if strlower(k)==str then
 				str = k	-- overwrite with key (in case of case mismatches)
 				ok = true
@@ -523,20 +523,20 @@ local function handle(info, inputpos, tab, depth, retfalse)
 			usererr(info, inputpos, "'"..str.."' - "..L["unknown selection"])
 			return
 		end
-		
+
 		do_final(info, inputpos, tab, "set", str)
-		
+
 	elseif tab.type=="multiselect" then
 		------------ multiselect -------------------------------------------
 		local str = strtrim(strlower(str))
-		
+
 		local values = tab.values
 		if type(values) == "function" or type(values) == "string" then
 			info.values = values
 			values = callmethod(info, inputpos, tab, "values")
 			info.values = nil
 		end
-		
+
 		if str == "" then
 			local fmt = "|cffffff78- [%s]|r %s"
 			local fmt_sel = "|cffffff78- [%s]|r %s |cffff0000*|r"
@@ -550,7 +550,7 @@ local function handle(info, inputpos, tab, depth, retfalse)
 			end
 			return
 		end
-		
+
 		--build a table of the selections, checking that they exist
 		--parse for =on =off =default in the process
 		--table will be key = true for options that should toggle, key = [on|off|default] for options to be set
@@ -559,25 +559,25 @@ local function handle(info, inputpos, tab, depth, retfalse)
 			--parse option=on etc
 			local opt, val = v:match('(.+)=(.+)')
 			--get option if toggling
-			if not opt then 
-				opt = v 
+			if not opt then
+				opt = v
 			end
-			
+
 			--check that the opt is valid
 			local ok
-			for k,v in pairs(values) do 
+			for k,v in pairs(values) do
 				if strlower(k)==opt then
 					opt = k	-- overwrite with key (in case of case mismatches)
 					ok = true
 					break
 				end
 			end
-			
+
 			if not ok then
 				usererr(info, inputpos, "'"..opt.."' - "..L["unknown selection"])
 				return
 			end
-			
+
 			--check that if val was supplied it is valid
 			if val then
 				if val == L["on"] or val == L["off"] or (tab.tristate and val == L["default"]) then
@@ -596,14 +596,14 @@ local function handle(info, inputpos, tab, depth, retfalse)
 				sels[opt] = true
 			end
 		end
-		
+
 		for opt, val in pairs(sels) do
 			local newval
-			
+
 			if (val == true) then
 				--toggle the option
 				local b = callmethod(info, inputpos, tab, "get", opt)
-				
+
 				if tab.tristate then
 					--cycle in true, nil, false order
 					if b then
@@ -627,11 +627,11 @@ local function handle(info, inputpos, tab, depth, retfalse)
 					newval = nil
 				end
 			end
-			
+
 			do_final(info, inputpos, tab, "set", opt, newval)
 		end
-					
-		
+
+
 	elseif tab.type=="color" then
 		------------ color --------------------------------------------
 		local str = strtrim(strlower(str))
@@ -639,16 +639,16 @@ local function handle(info, inputpos, tab, depth, retfalse)
 			--TODO: Show current value
 			return
 		end
-		
+
 		local r, g, b, a
-		
+
 		local hasAlpha = tab.hasAlpha
 		if type(hasAlpha) == "function" or type(hasAlpha) == "string" then
 			info.hasAlpha = hasAlpha
 			hasAlpha = callmethod(info, inputpos, tab, 'hasAlpha')
 			info.hasAlpha = nil
 		end
-		
+
 		if hasAlpha then
 			if str:len() == 8 and str:find("^%x*$")  then
 				--parse a hex string
@@ -662,7 +662,7 @@ local function handle(info, inputpos, tab, depth, retfalse)
 				usererr(info, inputpos, format(L["'%s' - expected 'RRGGBBAA' or 'r g b a'."], str))
 				return
 			end
-			
+
 			if r >= 0.0 and r <= 1.0 and g >= 0.0 and g <= 1.0 and b >= 0.0 and b <= 1.0 and a >= 0.0 and a <= 1.0 then
 				--values are valid
 			elseif r >= 0 and r <= 255 and g >= 0 and g <= 255 and b >= 0 and b <= 255 and a >= 0 and a <= 255 then
@@ -701,7 +701,7 @@ local function handle(info, inputpos, tab, depth, retfalse)
 				usererr(info, inputpos, format(L["'%s' - values must all be either in the range 0-1 or 0-255."], str))
 			end
 		end
-		
+
 		do_final(info, inputpos, tab, "set", r,g,b,a)
 
 	elseif tab.type=="keybinding" then
@@ -737,7 +737,7 @@ end
 -- MyAddon = LibStub("AceAddon-3.0"):NewAddon("MyAddon", "AceConsole-3.0")
 -- -- Use AceConsole-3.0 to register a Chat Command
 -- MyAddon:RegisterChatCommand("mychat", "ChatCommand")
--- 
+--
 -- -- Show the GUI if no input is supplied, otherwise handle the chat input.
 -- function MyAddon:ChatCommand(input)
 --   -- Assuming "MyOptions" is the appName of a valid options table
@@ -754,7 +754,7 @@ function AceConfigCmd:HandleCommand(slashcmd, appName, input)
 		error([[Usage: HandleCommand("slashcmd", "appName", "input"): 'appName' - no options table "]]..tostring(appName)..[[" has been registered]], 2)
 	end
 	local options = assert( optgetter("cmd", MAJOR) )
-	
+
 	local info = {   -- Don't try to recycle this, it gets handed off to callbacks and whatnot
 		[0] = slashcmd,
 		appName = appName,
@@ -765,7 +765,7 @@ function AceConfigCmd:HandleCommand(slashcmd, appName, input)
 		uiType = "cmd",
 		uiName = MAJOR,
 	}
-	
+
 	handle(info, 1, options, 0)  -- (info, inputpos, table, depth)
 end
 

--- a/Libs/AceConfig-3.0/AceConfigDialog-3.0/AceConfigDialog-3.0.lua
+++ b/Libs/AceConfig-3.0/AceConfigDialog-3.0/AceConfigDialog-3.0.lua
@@ -1,13 +1,13 @@
 --- AceConfigDialog-3.0 generates AceGUI-3.0 based windows based on option tables.
 -- @class file
 -- @name AceConfigDialog-3.0
--- @release $Id: AceConfigDialog-3.0.lua 1197 2019-01-21 23:41:10Z nevcairiel $
+-- @release $Id: AceConfigDialog-3.0.lua 1248 2021-02-05 14:27:49Z funkehdude $
 
 local LibStub = LibStub
 local gui = LibStub("AceGUI-3.0")
 local reg = LibStub("AceConfigRegistry-3.0")
 
-local MAJOR, MINOR = "AceConfigDialog-3.0", 69
+local MAJOR, MINOR = "AceConfigDialog-3.0", 81
 local AceConfigDialog, oldminor = LibStub:NewLibrary(MAJOR, MINOR)
 
 if not AceConfigDialog then return end
@@ -15,22 +15,23 @@ if not AceConfigDialog then return end
 AceConfigDialog.OpenFrames = AceConfigDialog.OpenFrames or {}
 AceConfigDialog.Status = AceConfigDialog.Status or {}
 AceConfigDialog.frame = AceConfigDialog.frame or CreateFrame("Frame")
+AceConfigDialog.tooltip = AceConfigDialog.tooltip or CreateFrame("GameTooltip", "AceConfigDialogTooltip", UIParent, "GameTooltipTemplate")
 
 AceConfigDialog.frame.apps = AceConfigDialog.frame.apps or {}
 AceConfigDialog.frame.closing = AceConfigDialog.frame.closing or {}
 AceConfigDialog.frame.closeAllOverride = AceConfigDialog.frame.closeAllOverride or {}
 
 -- Lua APIs
-local tinsert, tsort, tremove = table.insert, table.sort, table.remove
+local tinsert, tsort, tremove, wipe = table.insert, table.sort, table.remove, table.wipe
 local strmatch, format = string.match, string.format
 local error = error
-local pairs, next, select, type, unpack, wipe, ipairs = pairs, next, select, type, unpack, wipe, ipairs
+local pairs, next, select, type, unpack, ipairs = pairs, next, select, type, unpack, ipairs
 local tostring, tonumber = tostring, tonumber
 local math_min, math_max, math_floor = math.min, math.max, math.floor
 
 -- Global vars/functions that we don't upvalue since they might get hooked, or upgraded
 -- List them here for Mikk's FindGlobals script
--- GLOBALS: NORMAL_FONT_COLOR, GameTooltip, StaticPopupDialogs, ACCEPT, CANCEL, StaticPopup_Show
+-- GLOBALS: NORMAL_FONT_COLOR, ACCEPT, CANCEL
 -- GLOBALS: PlaySound, GameFontHighlight, GameFontHighlightSmall, GameFontHighlightLarge
 -- GLOBALS: CloseSpecialWindows, InterfaceOptions_AddCategory, geterrorhandler
 
@@ -56,18 +57,18 @@ local width_multiplier = 170
 --[[
 Group Types
   Tree 	- All Descendant Groups will all become nodes on the tree, direct child options will appear above the tree
-  		- Descendant Groups with inline=true and thier children will not become nodes
+        - Descendant Groups with inline=true and thier children will not become nodes
 
   Tab	- Direct Child Groups will become tabs, direct child options will appear above the tab control
-  		- Grandchild groups will default to inline unless specified otherwise
+        - Grandchild groups will default to inline unless specified otherwise
 
   Select- Same as Tab but with entries in a dropdown rather than tabs
 
 
   Inline Groups
-  	- Will not become nodes of a select group, they will be effectivly part of thier parent group seperated by a border
-  	- If declared on a direct child of a root node of a select group, they will appear above the group container control
-  	- When a group is displayed inline, all descendants will also be inline members of the group
+    - Will not become nodes of a select group, they will be effectivly part of thier parent group seperated by a border
+    - If declared on a direct child of a root node of a select group, they will appear above the group container control
+    - When a group is displayed inline, all descendants will also be inline members of the group
 
 ]]
 
@@ -168,11 +169,11 @@ local allIsLiteral = {
 local function GetOptionsMemberValue(membername, option, options, path, appName, ...)
 	--get definition for the member
 	local inherits = isInherited[membername]
-	
+
 
 	--get the member of the option, traversing the tree if it can be inherited
 	local member
-	
+
 	if inherits then
 		local group = options
 		if group[membername] ~= nil then
@@ -187,7 +188,7 @@ local function GetOptionsMemberValue(membername, option, options, path, appName,
 	else
 		member = option[membername]
 	end
-	
+
 	--check if we need to call a functon, or if we have a literal value
 	if ( not allIsLiteral[membername] ) and ( type(member) == "function" or ((not stringIsLiteral[membername]) and type(member) == "string") ) then
 		--We have a function to call
@@ -196,13 +197,13 @@ local function GetOptionsMemberValue(membername, option, options, path, appName,
 		local handler
 		local group = options
 		handler = group.handler or handler
-		
+
 		for i = 1, #path do
 			group = GetSubOption(group, path[i])
 			info[i] = path[i]
 			handler = group.handler or handler
 		end
-		
+
 		info.options = options
 		info.appName = appName
 		info[0] = appName
@@ -212,8 +213,8 @@ local function GetOptionsMemberValue(membername, option, options, path, appName,
 		info.type = option.type
 		info.uiType = "dialog"
 		info.uiName = MAJOR
-	
-		local a, b, c ,d 
+
+		local a, b, c ,d
 		--using 4 returns for the get of a color type, increase if a type needs more
 		if type(member) == "function" then
 			--Call the function
@@ -230,8 +231,8 @@ local function GetOptionsMemberValue(membername, option, options, path, appName,
 		return a,b,c,d
 	else
 		--The value isnt a function to call, return it
-		return member	
-	end	
+		return member
+	end
 end
 
 --[[calls an options function that could be inherited, method name or function ref
@@ -296,7 +297,7 @@ local function compareOptions(a,b)
 		return NameA:upper() < NameB:upper()
 	end
 	if OrderA < 0 then
-		if OrderB > 0 then
+		if OrderB >= 0 then
 			return false
 		end
 	else
@@ -315,7 +316,7 @@ end
 local function BuildSortedOptionsTable(group, keySort, opts, options, path, appName)
 	tempOrders = new()
 	tempNames = new()
-	
+
 	if group.plugins then
 		for plugin, t in pairs(group.plugins) do
 			for k, v in pairs(t) do
@@ -331,7 +332,7 @@ local function BuildSortedOptionsTable(group, keySort, opts, options, path, appN
 			end
 		end
 	end
-	
+
 	for k, v in pairs(group.args) do
 		if not opts[k] then
 			tinsert(keySort, k)
@@ -362,7 +363,7 @@ local function DelTree(tree)
 end
 
 local function CleanUserData(widget, event)
-	
+
 	local user = widget:GetUserDataTable()
 
 	if user.path then
@@ -402,7 +403,7 @@ end
 -- - Gets a status table for the given appname and options path.
 -- @param appName The application name as given to `:RegisterOptionsTable()`
 -- @param path The path to the options (a table with all group keys)
--- @return 
+-- @return
 function AceConfigDialog:GetStatusTable(appName, path)
 	local status = self.Status
 
@@ -436,7 +437,7 @@ end
 function AceConfigDialog:SelectGroup(appName, ...)
 	local path = new()
 
-	
+
 	local app = reg:GetOptionsTable(appName)
 	if not app then
 		error(("%s isn't registed with AceConfigRegistry, unable to open config"):format(appName), 2)
@@ -448,9 +449,9 @@ function AceConfigDialog:SelectGroup(appName, ...)
 		status.groups = {}
 	end
 	status = status.groups
-	local treevalue 
-	local treestatus 
-	
+	local treevalue
+	local treestatus
+
 	for n = 1, select("#",...) do
 		local key = select(n, ...)
 
@@ -477,12 +478,12 @@ function AceConfigDialog:SelectGroup(appName, ...)
 			--the selected group will be overwritten if a child is the final target but still needs to be open
 			treestatus.selected = treevalue
 			treestatus.groups[treevalue] = true
-			
+
 		end
-		
+
 		--move to the next group in the path
 		group = GetSubOption(group, key)
-		if not group then 
+		if not group then
 			break
 		end
 		tinsert(path, key)
@@ -492,10 +493,10 @@ function AceConfigDialog:SelectGroup(appName, ...)
 		end
 		status = status.groups
 	end
-	
+
 	del(path)
 	reg:NotifyChange(appName)
-end	
+end
 
 local function OptionOnMouseOver(widget, event)
 	--show a tooltip/set the status bar to the desc text
@@ -504,32 +505,33 @@ local function OptionOnMouseOver(widget, event)
 	local options = user.options
 	local path = user.path
 	local appName = user.appName
+	local tooltip = AceConfigDialog.tooltip
 
-	GameTooltip:SetOwner(widget.frame, "ANCHOR_TOPRIGHT")
+	tooltip:SetOwner(widget.frame, "ANCHOR_TOPRIGHT")
 	local name = GetOptionsMemberValue("name", opt, options, path, appName)
 	local desc = GetOptionsMemberValue("desc", opt, options, path, appName)
 	local usage = GetOptionsMemberValue("usage", opt, options, path, appName)
 	local descStyle = opt.descStyle
-	
+
 	if descStyle and descStyle ~= "tooltip" then return end
-	
-	GameTooltip:SetText(name, 1, .82, 0, true)
-	
+
+	tooltip:SetText(name, 1, .82, 0, true)
+
 	if opt.type == "multiselect" then
-		GameTooltip:AddLine(user.text, 0.5, 0.5, 0.8, true)
-	end	
+		tooltip:AddLine(user.text, 0.5, 0.5, 0.8, true)
+	end
 	if type(desc) == "string" then
-		GameTooltip:AddLine(desc, 1, 1, 1, true)
+		tooltip:AddLine(desc, 1, 1, 1, true)
 	end
 	if type(usage) == "string" then
-		GameTooltip:AddLine("Usage: "..usage, NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, true)
+		tooltip:AddLine("Usage: "..usage, NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, true)
 	end
 
-	GameTooltip:Show()
+	tooltip:Show()
 end
 
 local function OptionOnMouseLeave(widget, event)
-	GameTooltip:Hide()
+	AceConfigDialog.tooltip:Hide()
 end
 
 local function GetFuncName(option)
@@ -540,71 +542,127 @@ local function GetFuncName(option)
 		return "set"
 	end
 end
-local function confirmPopup(appName, rootframe, basepath, info, message, func, ...)
-	if not StaticPopupDialogs["ACECONFIGDIALOG30_CONFIRM_DIALOG"] then
-		StaticPopupDialogs["ACECONFIGDIALOG30_CONFIRM_DIALOG"] = {}
-	end
-	local t = StaticPopupDialogs["ACECONFIGDIALOG30_CONFIRM_DIALOG"]
-	for k in pairs(t) do
-		t[k] = nil
-	end
-	t.text = message
-	t.button1 = ACCEPT
-	t.button2 = CANCEL
-	t.preferredIndex = STATICPOPUP_NUMDIALOGS
-	local dialog, oldstrata
-	t.OnAccept = function()
-		safecall(func, unpack(t))
-		if dialog and oldstrata then
-			dialog:SetFrameStrata(oldstrata)
-		end
-		AceConfigDialog:Open(appName, rootframe, unpack(basepath or emptyTbl))
-		del(info)
-	end
-	t.OnCancel = function()
-		if dialog and oldstrata then
-			dialog:SetFrameStrata(oldstrata)
-		end
-		AceConfigDialog:Open(appName, rootframe, unpack(basepath or emptyTbl))
-		del(info)
-	end
-	for i = 1, select("#", ...) do
-		t[i] = select(i, ...) or false
-	end
-	t.timeout = 0
-	t.whileDead = 1
-	t.hideOnEscape = 1
+do
+	local frame = AceConfigDialog.popup
+	if not frame or oldminor < 81 then
+		frame = CreateFrame("Frame", nil, UIParent)
+		AceConfigDialog.popup = frame
+		frame:Hide()
+		frame:SetPoint("CENTER", UIParent, "CENTER")
+		frame:SetSize(320, 72)
+		frame:EnableMouse(true) -- Do not allow click-through on the frame
+		frame:SetFrameStrata("TOOLTIP")
+		frame:SetFrameLevel(100) -- Lots of room to draw under it
+		frame:SetScript("OnKeyDown", function(self, key)
+			if key == "ESCAPE" then
+				self:SetPropagateKeyboardInput(false)
+				if self.cancel:IsShown() then
+					self.cancel:Click()
+				else -- Showing a validation error
+					self:Hide()
+				end
+			else
+				self:SetPropagateKeyboardInput(true)
+			end
+		end)
 
-	dialog = StaticPopup_Show("ACECONFIGDIALOG30_CONFIRM_DIALOG")
-	if dialog then
-		oldstrata = dialog:GetFrameStrata()
-		dialog:SetFrameStrata("TOOLTIP")
+		if not frame.SetFixedFrameStrata then -- API capability check (classic check)
+			frame:SetBackdrop({
+				bgFile = [[Interface\DialogFrame\UI-DialogBox-Background-Dark]],
+				edgeFile = [[Interface\DialogFrame\UI-DialogBox-Border]],
+				tile = true,
+				tileSize = 32,
+				edgeSize = 32,
+				insets = { left = 11, right = 11, top = 11, bottom = 11 },
+			})
+		else
+			local border = CreateFrame("Frame", nil, frame, "DialogBorderOpaqueTemplate")
+			border:SetAllPoints(frame)
+			frame:SetFixedFrameStrata(true)
+			frame:SetFixedFrameLevel(true)
+		end
+
+		local text = frame:CreateFontString(nil, "ARTWORK", "GameFontHighlight")
+		text:SetSize(290, 0)
+		text:SetPoint("TOP", 0, -16)
+		frame.text = text
+
+		local function newButton(text)
+			local button = CreateFrame("Button", nil, frame)
+			button:SetSize(128, 21)
+			button:SetNormalFontObject(GameFontNormal)
+			button:SetHighlightFontObject(GameFontHighlight)
+			button:SetNormalTexture(130763) -- "Interface\\Buttons\\UI-DialogBox-Button-Up"
+			button:GetNormalTexture():SetTexCoord(0.0, 1.0, 0.0, 0.71875)
+			button:SetPushedTexture(130761) -- "Interface\\Buttons\\UI-DialogBox-Button-Down"
+			button:GetPushedTexture():SetTexCoord(0.0, 1.0, 0.0, 0.71875)
+			button:SetHighlightTexture(130762) -- "Interface\\Buttons\\UI-DialogBox-Button-Highlight"
+			button:GetHighlightTexture():SetTexCoord(0.0, 1.0, 0.0, 0.71875)
+			button:SetText(text)
+			return button
+		end
+
+		local accept = newButton(ACCEPT)
+		accept:SetPoint("BOTTOMRIGHT", frame, "BOTTOM", -6, 16)
+		frame.accept = accept
+
+		local cancel = newButton(CANCEL)
+		cancel:SetPoint("LEFT", accept, "RIGHT", 13, 0)
+		frame.cancel = cancel
 	end
+end
+local function confirmPopup(appName, rootframe, basepath, info, message, func, ...)
+	local frame = AceConfigDialog.popup
+	frame:Show()
+	frame.text:SetText(message)
+	-- From StaticPopup.lua
+	-- local height = 32 + text:GetHeight() + 2;
+	-- height = height + 6 + accept:GetHeight()
+	-- We add 32 + 2 + 6 + 21 (button height) == 61
+	local height = 61 + frame.text:GetHeight()
+	frame:SetHeight(height)
+
+	frame.accept:ClearAllPoints()
+	frame.accept:SetPoint("BOTTOMRIGHT", frame, "BOTTOM", -6, 16)
+	frame.cancel:Show()
+
+	local t = {...}
+	local tCount = select("#", ...)
+	frame.accept:SetScript("OnClick", function(self)
+		safecall(func, unpack(t, 1, tCount)) -- Manually set count as unpack() stops on nil (bug with #table)
+		AceConfigDialog:Open(appName, rootframe, unpack(basepath or emptyTbl))
+		frame:Hide()
+		self:SetScript("OnClick", nil)
+		frame.cancel:SetScript("OnClick", nil)
+		del(info)
+	end)
+	frame.cancel:SetScript("OnClick", function(self)
+		AceConfigDialog:Open(appName, rootframe, unpack(basepath or emptyTbl))
+		frame:Hide()
+		self:SetScript("OnClick", nil)
+		frame.accept:SetScript("OnClick", nil)
+		del(info)
+	end)
 end
 
 local function validationErrorPopup(message)
-	if not StaticPopupDialogs["ACECONFIGDIALOG30_VALIDATION_ERROR_DIALOG"] then
-		StaticPopupDialogs["ACECONFIGDIALOG30_VALIDATION_ERROR_DIALOG"] = {}
-	end
-	local t = StaticPopupDialogs["ACECONFIGDIALOG30_VALIDATION_ERROR_DIALOG"]
-	t.text = message
-	t.button1 = OKAY
-	t.preferredIndex = STATICPOPUP_NUMDIALOGS
-	local dialog, oldstrata
-	t.OnAccept = function()
-		if dialog and oldstrata then
-			dialog:SetFrameStrata(oldstrata)
-		end
-	end
-	t.timeout = 0
-	t.whileDead = 1
-	t.hideOnEscape = 1
+	local frame = AceConfigDialog.popup
+	frame:Show()
+	frame.text:SetText(message)
+	-- From StaticPopup.lua
+	-- local height = 32 + text:GetHeight() + 2;
+	-- height = height + 6 + accept:GetHeight()
+	-- We add 32 + 2 + 6 + 21 (button height) == 61
+	local height = 61 + frame.text:GetHeight()
+	frame:SetHeight(height)
 
-	dialog = StaticPopup_Show("ACECONFIGDIALOG30_VALIDATION_ERROR_DIALOG")
-	if dialog then
-		oldstrata = dialog:GetFrameStrata()
-		dialog:SetFrameStrata("TOOLTIP")
-	end
+	frame.accept:ClearAllPoints()
+	frame.accept:SetPoint("BOTTOM", frame, "BOTTOM", 0, 16)
+	frame.cancel:Hide()
+
+	frame.accept:SetScript("OnClick", function()
+		frame:Hide()
+	end)
 end
 
 local function ActivateControl(widget, event, ...)
@@ -675,7 +733,7 @@ local function ActivateControl(widget, event, ...)
 			end
 		end
 	end
-	
+
 	local success
 	if validated and option.type ~= "execute" then
 		if type(validate) == "string" then
@@ -690,7 +748,7 @@ local function ActivateControl(widget, event, ...)
 			if not success then validated = false end
 		end
 	end
-	
+
 	local rootframe = user.rootframe
 	if not validated or type(validated) == "string" then
 		if not validated then
@@ -715,7 +773,7 @@ local function ActivateControl(widget, event, ...)
 		del(info)
 		return true
 	else
-		
+
 		local confirmText = option.confirmText
 		--call confirm func/method
 		if type(confirm) == "string" then
@@ -756,10 +814,10 @@ local function ActivateControl(widget, event, ...)
 						confirmText = confirmText.." - "..desc
 					end
 				end
-				
+
 				local iscustom = user.rootframe:GetUserData("iscustom")
 				local rootframe
-				
+
 				if iscustom then
 					rootframe = user.rootframe
 				end
@@ -796,7 +854,7 @@ local function ActivateControl(widget, event, ...)
 		--full refresh of the frame, some controls dont cause this on all events
 		if option.type == "color" then
 			if event == "OnValueConfirmed" then
-				
+
 				if iscustom then
 					AceConfigDialog:Open(user.appName, user.rootframe, unpack(basepath))
 				else
@@ -857,7 +915,7 @@ end
 
 local function MultiControlOnClosed(widget, event, ...)
 	local user = widget:GetUserDataTable()
-	if user.valuechanged then
+	if user.valuechanged and not widget:IsReleasing() then
 		local iscustom = user.rootframe:GetUserData("iscustom")
 		local basepath = user.rootframe:GetUserData("basepath") or emptyTbl
 		if iscustom then
@@ -1049,6 +1107,10 @@ local function CreateControl(userControlType, fallbackControlType)
 	return control
 end
 
+local function sortTblAsStrings(x,y)
+	return tostring(x) < tostring(y) -- Support numbers as keys
+end
+
 --[[
 	options - root of the options table being fed
 	container - widget that controls will be placed in
@@ -1079,7 +1141,7 @@ local function FeedOptions(appName, options,container,rootframe,path,group,inlin
 					else
 						GroupContainer = gui:Create("SimpleGroup")
 					end
-					
+
 					GroupContainer.width = "fill"
 					GroupContainer:SetLayout("flow")
 					container:AddChild(GroupContainer)
@@ -1088,14 +1150,14 @@ local function FeedOptions(appName, options,container,rootframe,path,group,inlin
 			else
 				--Control to feed
 				local control
-				
+
 				local name = GetOptionsMemberValue("name", v, options, path, appName)
-				
+
 				if v.type == "execute" then
-					
+
 					local imageCoords = GetOptionsMemberValue("imageCoords",v, options, path, appName)
 					local image, width, height = GetOptionsMemberValue("image",v, options, path, appName)
-					
+
 					local iconControl = type(image) == "string" or type(image) == "number"
 					control = CreateControl(v.dialogControl or v.control, iconControl and "Icon" or "Button")
 					if iconControl then
@@ -1125,7 +1187,7 @@ local function FeedOptions(appName, options,container,rootframe,path,group,inlin
 
 				elseif v.type == "input" then
 					control = CreateControl(v.dialogControl or v.control, v.multiline and "MultiLineEditBox" or "EditBox")
-					
+
 					if v.multiline and control.SetNumLines then
 						control:SetNumLines(tonumber(v.multiline) or 4)
 					end
@@ -1144,15 +1206,15 @@ local function FeedOptions(appName, options,container,rootframe,path,group,inlin
 					local value = GetOptionsMemberValue("get",v, options, path, appName)
 					control:SetValue(value)
 					control:SetCallback("OnValueChanged",ActivateControl)
-					
+
 					if v.descStyle == "inline" then
 						local desc = GetOptionsMemberValue("desc", v, options, path, appName)
 						control:SetDescription(desc)
 					end
-					
+
 					local image = GetOptionsMemberValue("image", v, options, path, appName)
 					local imageCoords = GetOptionsMemberValue("imageCoords", v, options, path, appName)
-					
+
 					if type(image) == "string" or type(image) == "number" then
 						if type(imageCoords) == "table" then
 							control:SetImage(image, unpack(imageCoords))
@@ -1175,6 +1237,7 @@ local function FeedOptions(appName, options,container,rootframe,path,group,inlin
 
 				elseif v.type == "select" then
 					local values = GetOptionsMemberValue("values", v, options, path, appName)
+					local sorting = GetOptionsMemberValue("sorting", v, options, path, appName)
 					if v.style == "radio" then
 						local disabled = CheckOptionDisabled(v, options, path, appName)
 						local width = GetOptionsMemberValue("width",v,options,path,appName)
@@ -1185,12 +1248,14 @@ local function FeedOptions(appName, options,container,rootframe,path,group,inlin
 
 						control:PauseLayout()
 						local optionValue = GetOptionsMemberValue("get",v, options, path, appName)
-						local t = {}
-						for value, text in pairs(values) do
-							t[#t+1]=value
+						if not sorting then
+							sorting = {}
+							for value, text in pairs(values) do
+								sorting[#sorting+1]=value
+							end
+							tsort(sorting, sortTblAsStrings)
 						end
-						tsort(t)
-						for k, value in ipairs(t) do
+						for k, value in ipairs(sorting) do
 							local text = values[value]
 							local radio = gui:Create("CheckBox")
 							radio:SetLabel(text)
@@ -1224,7 +1289,7 @@ local function FeedOptions(appName, options,container,rootframe,path,group,inlin
 							itemType = nil
 						end
 						control:SetLabel(name)
-						control:SetList(values, nil, itemType)
+						control:SetList(values, sorting, itemType)
 						local value = GetOptionsMemberValue("get",v, options, path, appName)
 						if not values[value] then
 							value = nil
@@ -1236,7 +1301,7 @@ local function FeedOptions(appName, options,container,rootframe,path,group,inlin
 				elseif v.type == "multiselect" then
 					local values = GetOptionsMemberValue("values", v, options, path, appName)
 					local disabled = CheckOptionDisabled(v, options, path, appName)
-					
+
 					local valuesort = new()
 					if values then
 						for value, text in pairs(values) do
@@ -1244,7 +1309,7 @@ local function FeedOptions(appName, options,container,rootframe,path,group,inlin
 						end
 					end
 					tsort(valuesort)
-					
+
 					local controlType = v.dialogControl or v.control
 					if controlType then
 						control = gui:Create(controlType)
@@ -1313,9 +1378,9 @@ local function FeedOptions(appName, options,container,rootframe,path,group,inlin
 						control:ResumeLayout()
 						control:DoLayout()
 
-						
+
 					end
-					
+
 					del(valuesort)
 
 				elseif v.type == "color" then
@@ -1340,7 +1405,7 @@ local function FeedOptions(appName, options,container,rootframe,path,group,inlin
 				elseif v.type == "description" then
 					control = CreateControl(v.dialogControl or v.control, "Label")
 					control:SetText(name)
-					
+
 					local fontSize = GetOptionsMemberValue("fontSize",v, options, path, appName)
 					if fontSize == "medium" then
 						control:SetFontObject(GameFontHighlight)
@@ -1349,10 +1414,10 @@ local function FeedOptions(appName, options,container,rootframe,path,group,inlin
 					else -- small or invalid
 						control:SetFontObject(GameFontHighlightSmall)
 					end
-					
+
 					local imageCoords = GetOptionsMemberValue("imageCoords",v, options, path, appName)
 					local image, width, height = GetOptionsMemberValue("image",v, options, path, appName)
-					
+
 					if type(image) == "string" or type(image) == "number" then
 						if not width then
 							width = GetOptionsMemberValue("imageWidth",v, options, path, appName)
@@ -1401,7 +1466,7 @@ local function FeedOptions(appName, options,container,rootframe,path,group,inlin
 					InjectInfo(control, options, v, path, rootframe, appName)
 					container:AddChild(control)
 				end
-				
+
 			end
 		end
 		tremove(path)
@@ -1426,7 +1491,8 @@ local function TreeOnButtonEnter(widget, event, uniquevalue, button)
 	local option = user.option
 	local path = user.path
 	local appName = user.appName
-	
+	local tooltip = AceConfigDialog.tooltip
+
 	local feedpath = new()
 	for i = 1, #path do
 		feedpath[i] = path[i]
@@ -1441,49 +1507,50 @@ local function TreeOnButtonEnter(widget, event, uniquevalue, button)
 
 	local name = GetOptionsMemberValue("name", group, options, feedpath, appName)
 	local desc = GetOptionsMemberValue("desc", group, options, feedpath, appName)
-	
-	GameTooltip:SetOwner(button, "ANCHOR_NONE")
+
+	tooltip:SetOwner(button, "ANCHOR_NONE")
+	tooltip:ClearAllPoints()
 	if widget.type == "TabGroup" then
-		GameTooltip:SetPoint("BOTTOM",button,"TOP")
+		tooltip:SetPoint("BOTTOM",button,"TOP")
 	else
-		GameTooltip:SetPoint("LEFT",button,"RIGHT")
+		tooltip:SetPoint("LEFT",button,"RIGHT")
 	end
 
-	GameTooltip:SetText(name, 1, .82, 0, true)
-	
+	tooltip:SetText(name, 1, .82, 0, true)
+
 	if type(desc) == "string" then
-		GameTooltip:AddLine(desc, 1, 1, 1, true)
+		tooltip:AddLine(desc, 1, 1, 1, true)
 	end
-	
-	GameTooltip:Show()
+
+	tooltip:Show()
 end
 
 local function TreeOnButtonLeave(widget, event, value, button)
-	GameTooltip:Hide()
+	AceConfigDialog.tooltip:Hide()
 end
 
 
 local function GroupExists(appName, options, path, uniquevalue)
 	if not uniquevalue then return false end
-	
+
 	local feedpath = new()
 	local temppath = new()
 	for i = 1, #path do
 		feedpath[i] = path[i]
 	end
-	
+
 	BuildPath(feedpath, ("\001"):split(uniquevalue))
-	
+
 	local group = options
 	for i = 1, #feedpath do
 		local v = feedpath[i]
 		temppath[i] = v
 		group = GetSubOption(group, v)
-		
-		if not group or group.type ~= "group" or CheckOptionHidden(group, options, temppath, appName) then 
+
+		if not group or group.type ~= "group" or CheckOptionHidden(group, options, temppath, appName) then
 			del(feedpath)
 			del(temppath)
-			return false 
+			return false
 		end
 	end
 	del(feedpath)
@@ -1602,7 +1669,7 @@ function AceConfigDialog:FeedGroup(appName,options,container,rootframe,path, isR
 			tab:SetCallback("OnGroupSelected", GroupSelected)
 			tab:SetCallback("OnTabEnter", TreeOnButtonEnter)
 			tab:SetCallback("OnTabLeave", TreeOnButtonLeave)
-			
+
 			local status = AceConfigDialog:GetStatusTable(appName, path)
 			if not status.groups then
 				status.groups = {}
@@ -1622,7 +1689,7 @@ function AceConfigDialog:FeedGroup(appName,options,container,rootframe,path, isR
 					break
 				end
 			end
-			
+
 			container:AddChild(tab)
 
 		elseif grouptype == "select" then
@@ -1645,7 +1712,7 @@ function AceConfigDialog:FeedGroup(appName,options,container,rootframe,path, isR
 			if firstgroup then
 				select:SetGroup((GroupExists(appName, options, path,status.groups.selected) and status.groups.selected) or firstgroup)
 			end
-			
+
 			select.width = "fill"
 			select.height = "fill"
 
@@ -1657,14 +1724,14 @@ function AceConfigDialog:FeedGroup(appName,options,container,rootframe,path, isR
 			local tree = gui:Create("TreeGroup")
 			InjectInfo(tree, options, group, path, rootframe, appName)
 			tree:EnableButtonTooltips(false)
-			
+
 			tree.width = "fill"
 			tree.height = "fill"
 
 			tree:SetCallback("OnGroupSelected", GroupSelected)
 			tree:SetCallback("OnButtonEnter", TreeOnButtonEnter)
 			tree:SetCallback("OnButtonLeave", TreeOnButtonLeave)
-			
+
 			local status = AceConfigDialog:GetStatusTable(appName, path)
 			if not status.groups then
 				status.groups = {}
@@ -1705,7 +1772,7 @@ local function RefreshOnUpdate(this)
 		end
 		this.closing[appName] = nil
 	end
-	
+
 	if this.closeAll then
 		for k, v in pairs(AceConfigDialog.OpenFrames) do
 			if not this.closeAllOverride[k] then
@@ -1715,7 +1782,7 @@ local function RefreshOnUpdate(this)
 		this.closeAll = nil
 		wipe(this.closeAllOverride)
 	end
-	
+
 	for appName in pairs(this.apps) do
 		if AceConfigDialog.OpenFrames[appName] then
 			local user = AceConfigDialog.OpenFrames[appName]:GetUserDataTable()
@@ -1800,10 +1867,10 @@ function AceConfigDialog:Open(appName, container, ...)
 	local options = app("dialog", MAJOR)
 
 	local f
-	
+
 	local path = new()
 	local name = GetOptionsMemberValue("name", options, options, path, appName)
-	
+
 	--If an optional path is specified add it to the path table before feeding the options
 	--as container is optional as well it may contain the first element of the path
 	if type(container) == "string" then
@@ -1813,7 +1880,7 @@ function AceConfigDialog:Open(appName, container, ...)
 	for n = 1, select("#",...) do
 		tinsert(path, (select(n, ...)))
 	end
-	
+
 	local option = options
 	if type(container) == "table" and container.type == "BlizOptionsGroup" and #path > 0 then
 		for i = 1, #path do
@@ -1821,7 +1888,7 @@ function AceConfigDialog:Open(appName, container, ...)
 		end
 		name = format("%s - %s", name, GetOptionsMemberValue("name", option, options, path, appName))
 	end
-	
+
 	--if a container is given feed into that
 	if container then
 		f = container
@@ -1915,19 +1982,19 @@ end
 -- @param name A descriptive name to display in the options tree (defaults to appName)
 -- @param parent The parent to use in the interface options tree.
 -- @param ... The path in the options table to feed into the interface options panel.
--- @return The reference to the frame registered into the Interface Options. 
+-- @return The reference to the frame registered into the Interface Options.
 function AceConfigDialog:AddToBlizOptions(appName, name, parent, ...)
 	local BlizOptions = AceConfigDialog.BlizOptions
-	
+
 	local key = appName
 	for n = 1, select("#", ...) do
 		key = key.."\001"..select(n, ...)
 	end
-	
+
 	if not BlizOptions[appName] then
 		BlizOptions[appName] = {}
 	end
-	
+
 	if not BlizOptions[appName][key] then
 		local group = gui:Create("BlizOptionsGroup")
 		BlizOptions[appName][key] = group

--- a/Libs/AceConfig-3.0/AceConfigRegistry-3.0/AceConfigRegistry-3.0.lua
+++ b/Libs/AceConfig-3.0/AceConfigRegistry-3.0/AceConfigRegistry-3.0.lua
@@ -4,14 +4,14 @@
 -- * Valid **uiTypes**: "cmd", "dropdown", "dialog". This is verified by the library at call time. \\
 -- * The **uiName** field is expected to contain the full name of the calling addon, including version, e.g. "FooBar-1.0". This is verified by the library at call time.\\
 -- * The **appName** field is the options table name as given at registration time \\
--- 
+--
 -- :IterateOptionsTables() (and :GetOptionsTable() if only given one argument) return a function reference that the requesting config handling addon must call with valid "uiType", "uiName".
 -- @class file
 -- @name AceConfigRegistry-3.0
--- @release $Id: AceConfigRegistry-3.0.lua 1193 2018-08-02 12:24:37Z funkydude $
+-- @release $Id: AceConfigRegistry-3.0.lua 1207 2019-06-23 12:08:33Z nevcairiel $
 local CallbackHandler = LibStub("CallbackHandler-1.0")
 
-local MAJOR, MINOR = "AceConfigRegistry-3.0", 18
+local MAJOR, MINOR = "AceConfigRegistry-3.0", 20
 local AceConfigRegistry = LibStub:NewLibrary(MAJOR, MINOR)
 
 if not AceConfigRegistry then return end
@@ -33,7 +33,7 @@ local error, assert = error, assert
 
 
 AceConfigRegistry.validated = {
-	-- list of options table names ran through :ValidateOptionsTable automatically. 
+	-- list of options table names ran through :ValidateOptionsTable automatically.
 	-- CLEARED ON PURPOSE, since newer versions may have newer validators
 	cmd = {},
 	dropdown = {},
@@ -94,13 +94,20 @@ local basekeys={
 }
 
 local typedkeys={
-	header={},
+	header={
+		control=optstring,
+		dialogControl=optstring,
+		dropdownControl=optstring,
+	},
 	description={
 		image=optstringnumberfunc,
 		imageCoords=optmethodtable,
 		imageHeight=optnumber,
 		imageWidth=optnumber,
 		fontSize=optstringfunc,
+		control=optstring,
+		dialogControl=optstring,
+		dropdownControl=optstring,
 	},
 	group={
 		args=istable,
@@ -117,6 +124,9 @@ local typedkeys={
 		imageCoords=optmethodtable,
 		imageHeight=optnumber,
 		imageWidth=optnumber,
+		control=optstring,
+		dialogControl=optstring,
+		dropdownControl=optstring,
 	},
 	input={
 		pattern=optstring,
@@ -130,6 +140,9 @@ local typedkeys={
 		tristate=optbool,
 		image=optstringnumberfunc,
 		imageCoords=optmethodtable,
+		control=optstring,
+		dialogControl=optstring,
+		dropdownControl=optstring,
 	},
 	tristate={
 	},
@@ -141,12 +154,16 @@ local typedkeys={
 		step=optnumber,
 		bigStep=optnumber,
 		isPercent=optbool,
+		control=optstring,
+		dialogControl=optstring,
+		dropdownControl=optstring,
 	},
 	select={
 		values=ismethodtable,
+		sorting=optmethodtable,
 		style={
-			["nil"]=true, 
-			["string"]={dropdown=true,radio=true}, 
+			["nil"]=true,
+			["string"]={dropdown=true,radio=true},
 			_="string: 'dropdown' or 'radio'"
 		},
 		control=optstring,
@@ -164,9 +181,14 @@ local typedkeys={
 	},
 	color={
 		hasAlpha=optmethodbool,
+		control=optstring,
+		dialogControl=optstring,
+		dropdownControl=optstring,
 	},
 	keybinding={
-		-- TODO
+		control=optstring,
+		dialogControl=optstring,
+		dropdownControl=optstring,
 	},
 }
 
@@ -203,13 +225,13 @@ local function validate(options,errlvl,...)
 	if type(options.type)~="string" then
 		err(".type: expected a string, got a "..type(options.type), errlvl,...)
 	end
-	
+
 	-- get type and 'typedkeys' member
 	local tk = typedkeys[options.type]
 	if not tk then
 		err(".type: unknown type '"..options.type.."'", errlvl,...)
 	end
-	
+
 	-- make sure that all options[] are known parameters
 	for k,v in pairs(options) do
 		if not (tk[k] or basekeys[k]) then
@@ -302,7 +324,7 @@ function AceConfigRegistry:RegisterOptionsTable(appName, options, skipValidation
 				AceConfigRegistry:ValidateOptionsTable(options, appName, errlvl)	-- upgradable
 				AceConfigRegistry.validated[uiType][appName] = true
 			end
-			return options 
+			return options
 		end
 	elseif type(options)=="function" then
 		AceConfigRegistry.tables[appName] = function(uiType, uiName, errlvl)
@@ -340,7 +362,7 @@ function AceConfigRegistry:GetOptionsTable(appName, uiType, uiName)
 	if not f then
 		return nil
 	end
-	
+
 	if uiType then
 		return f(uiType,uiName,1)	-- get the table for us
 	else

--- a/Libs/AceConsole-3.0/AceConsole-3.0.lua
+++ b/Libs/AceConsole-3.0/AceConsole-3.0.lua
@@ -2,14 +2,14 @@
 -- You can register slash commands to your custom functions and use the `GetArgs` function to parse them
 -- to your addons individual needs.
 --
--- **AceConsole-3.0** can be embeded into your addon, either explicitly by calling AceConsole:Embed(MyAddon) or by 
+-- **AceConsole-3.0** can be embeded into your addon, either explicitly by calling AceConsole:Embed(MyAddon) or by
 -- specifying it as an embeded library in your AceAddon. All functions will be available on your addon object
 -- and can be accessed directly, without having to explicitly call AceConsole itself.\\
 -- It is recommended to embed AceConsole, otherwise you'll have to specify a custom `self` on all calls you
 -- make into AceConsole.
 -- @class file
 -- @name AceConsole-3.0
--- @release $Id: AceConsole-3.0.lua 1143 2016-07-11 08:52:03Z nevcairiel $
+-- @release $Id: AceConsole-3.0.lua 1202 2019-05-15 23:11:22Z nevcairiel $
 local MAJOR,MINOR = "AceConsole-3.0", 7
 
 local AceConsole, oldminor = LibStub:NewLibrary(MAJOR, MINOR)
@@ -84,11 +84,11 @@ end
 -- @param persist if false, the command will be soft disabled/enabled when aceconsole is used as a mixin (default: true)
 function AceConsole:RegisterChatCommand( command, func, persist )
 	if type(command)~="string" then error([[Usage: AceConsole:RegisterChatCommand( "command", func[, persist ]): 'command' - expected a string]], 2) end
-	
+
 	if persist==nil then persist=true end	-- I'd rather have my addon's "/addon enable" around if the author screws up. Having some extra slash regged when it shouldnt be isn't as destructive. True is a better default. /Mikk
-	
+
 	local name = "ACECONSOLE_"..command:upper()
-	
+
 	if type( func ) == "string" then
 		SlashCmdList[name] = function(input, editBox)
 			self[func](self, input, editBox)
@@ -132,9 +132,9 @@ local function nils(n, ...)
 		return ...
 	end
 end
-	
 
---- Retreive one or more space-separated arguments from a string. 
+
+--- Retreive one or more space-separated arguments from a string.
 -- Treats quoted strings and itemlinks as non-spaced.
 -- @param str The raw argument string
 -- @param numargs How many arguments to get (default 1)
@@ -144,7 +144,7 @@ end
 function AceConsole:GetArgs(str, numargs, startpos)
 	numargs = numargs or 1
 	startpos = max(startpos or 1, 1)
-	
+
 	local pos=startpos
 
 	-- find start of new arg
@@ -169,24 +169,24 @@ function AceConsole:GetArgs(str, numargs, startpos)
 	else
 		delim_or_pipe="([| ])"
 	end
-	
+
 	startpos = pos
-	
+
 	while true do
 		-- find delimiter or hyperlink
 		local ch,_
 		pos,_,ch = strfind(str, delim_or_pipe, pos)
-		
+
 		if not pos then break end
-		
+
 		if ch=="|" then
 			-- some kind of escape
-			
+
 			if strsub(str,pos,pos+1)=="|H" then
 				-- It's a |H....|hhyper link!|h
 				pos=strfind(str, "|h", pos+2)	-- first |h
 				if not pos then break end
-				
+
 				pos=strfind(str, "|h", pos+2)	-- second |h
 				if not pos then break end
 			elseif strsub(str,pos, pos+1) == "|T" then
@@ -194,16 +194,16 @@ function AceConsole:GetArgs(str, numargs, startpos)
 				pos=strfind(str, "|t", pos+2)
 				if not pos then break end
 			end
-			
+
 			pos=pos+2 -- skip past this escape (last |h if it was a hyperlink)
-		
+
 		else
 			-- found delimiter, done with this arg
 			return strsub(str, startpos, pos-1), AceConsole:GetArgs(str, numargs-1, pos+1)
 		end
-		
+
 	end
-	
+
 	-- search aborted, we hit end of string. return it all as one argument. (yes, even if it's an unterminated quote or hyperlink)
 	return strsub(str, startpos), nils(numargs-1, 1e9)
 end
@@ -214,10 +214,10 @@ end
 local mixins = {
 	"Print",
 	"Printf",
-	"RegisterChatCommand", 
+	"RegisterChatCommand",
 	"UnregisterChatCommand",
 	"GetArgs",
-} 
+}
 
 -- Embeds AceConsole into the target object making the functions from the mixins list available on target:..
 -- @param target target object to embed AceBucket in

--- a/Libs/AceDB-3.0/AceDB-3.0.lua
+++ b/Libs/AceDB-3.0/AceDB-3.0.lua
@@ -40,8 +40,8 @@
 -- end
 -- @class file
 -- @name AceDB-3.0.lua
--- @release $Id: AceDB-3.0.lua 1193 2018-08-02 12:24:37Z funkydude $
-local ACEDB_MAJOR, ACEDB_MINOR = "AceDB-3.0", 26
+-- @release $Id: AceDB-3.0.lua 1217 2019-07-11 03:06:18Z funkydude $
+local ACEDB_MAJOR, ACEDB_MINOR = "AceDB-3.0", 27
 local AceDB = LibStub:NewLibrary(ACEDB_MAJOR, ACEDB_MINOR)
 
 if not AceDB then return end -- No upgrade needed
@@ -397,7 +397,7 @@ AceDB.frame:SetScript("OnEvent", logoutHandler)
 -- @param defaults A table of defaults for this database
 function DBObjectLib:RegisterDefaults(defaults)
 	if defaults and type(defaults) ~= "table" then
-		error("Usage: AceDBObject:RegisterDefaults(defaults): 'defaults' - table or nil expected.", 2)
+		error(("Usage: AceDBObject:RegisterDefaults(defaults): 'defaults' - table or nil expected, got %q."):format(type(defaults)), 2)
 	end
 
 	validateDefaults(defaults, self.keys)
@@ -429,7 +429,7 @@ end
 -- @param name The name of the profile to set as the current profile
 function DBObjectLib:SetProfile(name)
 	if type(name) ~= "string" then
-		error("Usage: AceDBObject:SetProfile(name): 'name' - string expected.", 2)
+		error(("Usage: AceDBObject:SetProfile(name): 'name' - string expected, got %q."):format(type(name)), 2)
 	end
 
 	-- changing to the same profile, dont do anything
@@ -471,7 +471,7 @@ end
 -- @param tbl A table to store the profile names in (optional)
 function DBObjectLib:GetProfiles(tbl)
 	if tbl and type(tbl) ~= "table" then
-		error("Usage: AceDBObject:GetProfiles(tbl): 'tbl' - table or nil expected.", 2)
+		error(("Usage: AceDBObject:GetProfiles(tbl): 'tbl' - table or nil expected, got %q."):format(type(tbl)), 2)
 	end
 
 	-- Clear the container table
@@ -509,15 +509,15 @@ end
 -- @param silent If true, do not raise an error when the profile does not exist
 function DBObjectLib:DeleteProfile(name, silent)
 	if type(name) ~= "string" then
-		error("Usage: AceDBObject:DeleteProfile(name): 'name' - string expected.", 2)
+		error(("Usage: AceDBObject:DeleteProfile(name): 'name' - string expected, got %q."):format(type(name)), 2)
 	end
 
 	if self.keys.profile == name then
-		error("Cannot delete the active profile in an AceDBObject.", 2)
+		error(("Cannot delete the active profile (%q) in an AceDBObject."):format(name), 2)
 	end
 
 	if not rawget(self.profiles, name) and not silent then
-		error("Cannot delete profile '" .. name .. "'. It does not exist.", 2)
+		error(("Cannot delete profile %q as it does not exist."):format(name), 2)
 	end
 
 	self.profiles[name] = nil
@@ -548,15 +548,15 @@ end
 -- @param silent If true, do not raise an error when the profile does not exist
 function DBObjectLib:CopyProfile(name, silent)
 	if type(name) ~= "string" then
-		error("Usage: AceDBObject:CopyProfile(name): 'name' - string expected.", 2)
+		error(("Usage: AceDBObject:CopyProfile(name): 'name' - string expected, got %q."):format(type(name)), 2)
 	end
 
 	if name == self.keys.profile then
-		error("Cannot have the same source and destination profiles.", 2)
+		error(("Cannot have the same source and destination profiles (%q)."):format(name), 2)
 	end
 
 	if not rawget(self.profiles, name) and not silent then
-		error("Cannot copy profile '" .. name .. "'. It does not exist.", 2)
+		error(("Cannot copy profile %q as it does not exist."):format(name), 2)
 	end
 
 	-- Reset the profile before copying
@@ -611,7 +611,7 @@ end
 -- @param defaultProfile The profile name to use as the default
 function DBObjectLib:ResetDB(defaultProfile)
 	if defaultProfile and type(defaultProfile) ~= "string" then
-		error("Usage: AceDBObject:ResetDB(defaultProfile): 'defaultProfile' - string or nil expected.", 2)
+		error(("Usage: AceDBObject:ResetDB(defaultProfile): 'defaultProfile' - string or nil expected, got %q."):format(type(defaultProfile)), 2)
 	end
 
 	local sv = self.sv
@@ -645,13 +645,13 @@ end
 -- @param defaults A table of values to use as defaults
 function DBObjectLib:RegisterNamespace(name, defaults)
 	if type(name) ~= "string" then
-		error("Usage: AceDBObject:RegisterNamespace(name, defaults): 'name' - string expected.", 2)
+		error(("Usage: AceDBObject:RegisterNamespace(name, defaults): 'name' - string expected, got %q."):format(type(name)), 2)
 	end
 	if defaults and type(defaults) ~= "table" then
-		error("Usage: AceDBObject:RegisterNamespace(name, defaults): 'defaults' - table or nil expected.", 2)
+		error(("Usage: AceDBObject:RegisterNamespace(name, defaults): 'defaults' - table or nil expected, got %q."):format(type(defaults)), 2)
 	end
 	if self.children and self.children[name] then
-		error ("Usage: AceDBObject:RegisterNamespace(name, defaults): 'name' - a namespace with that name already exists.", 2)
+		error(("Usage: AceDBObject:RegisterNamespace(name, defaults): 'name' - a namespace called %q already exists."):format(name), 2)
 	end
 
 	local sv = self.sv
@@ -675,10 +675,10 @@ end
 -- @return the namespace object if found
 function DBObjectLib:GetNamespace(name, silent)
 	if type(name) ~= "string" then
-		error("Usage: AceDBObject:GetNamespace(name): 'name' - string expected.", 2)
+		error(("Usage: AceDBObject:GetNamespace(name): 'name' - string expected, got %q."):format(type(name)), 2)
 	end
 	if not silent and not (self.children and self.children[name]) then
-		error ("Usage: AceDBObject:GetNamespace(name): 'name' - namespace does not exist.", 2)
+		error(("Usage: AceDBObject:GetNamespace(name): 'name' - namespace %q does not exist."):format(name), 2)
 	end
 	if not self.children then self.children = {} end
 	return self.children[name]
@@ -717,15 +717,15 @@ function AceDB:New(tbl, defaults, defaultProfile)
 	end
 
 	if type(tbl) ~= "table" then
-		error("Usage: AceDB:New(tbl, defaults, defaultProfile): 'tbl' - table expected.", 2)
+		error(("Usage: AceDB:New(tbl, defaults, defaultProfile): 'tbl' - table expected, got %q."):format(type(tbl)), 2)
 	end
 
 	if defaults and type(defaults) ~= "table" then
-		error("Usage: AceDB:New(tbl, defaults, defaultProfile): 'defaults' - table expected.", 2)
+		error(("Usage: AceDB:New(tbl, defaults, defaultProfile): 'defaults' - table expected, got %q."):format(type(defaults)), 2)
 	end
 
 	if defaultProfile and type(defaultProfile) ~= "string" and defaultProfile ~= true then
-		error("Usage: AceDB:New(tbl, defaults, defaultProfile): 'defaultProfile' - string or true expected.", 2)
+		error(("Usage: AceDB:New(tbl, defaults, defaultProfile): 'defaultProfile' - string or true expected, got %q."):format(type(defaultProfile)), 2)
 	end
 
 	return initdb(tbl, defaults, defaultProfile)

--- a/Libs/AceDBOptions-3.0/AceDBOptions-3.0.lua
+++ b/Libs/AceDBOptions-3.0/AceDBOptions-3.0.lua
@@ -1,7 +1,7 @@
 --- AceDBOptions-3.0 provides a universal AceConfig options screen for managing AceDB-3.0 profiles.
 -- @class file
 -- @name AceDBOptions-3.0
--- @release $Id: AceDBOptions-3.0.lua 1193 2018-08-02 12:24:37Z funkydude $
+-- @release $Id: AceDBOptions-3.0.lua 1202 2019-05-15 23:11:22Z nevcairiel $
 local ACEDBO_MAJOR, ACEDBO_MINOR = "AceDBOptions-3.0", 15
 local AceDBOptions = LibStub:NewLibrary(ACEDBO_MAJOR, ACEDBO_MINOR)
 
@@ -240,22 +240,22 @@ local tmpprofiles = {}
 -- @return Hashtable of all profiles with the internal name as keys and the display name as value.
 local function getProfileList(db, common, nocurrent)
 	local profiles = {}
-	
+
 	-- copy existing profiles into the table
 	local currentProfile = db:GetCurrentProfile()
-	for i,v in pairs(db:GetProfiles(tmpprofiles)) do 
-		if not (nocurrent and v == currentProfile) then 
-			profiles[v] = v 
-		end 
+	for i,v in pairs(db:GetProfiles(tmpprofiles)) do
+		if not (nocurrent and v == currentProfile) then
+			profiles[v] = v
+		end
 	end
-	
+
 	-- add our default profiles to choose from ( or rename existing profiles)
 	for k,v in pairs(defaultProfiles) do
 		if (common or profiles[k]) and not (nocurrent and k == currentProfile) then
 			profiles[k] = v
 		end
 	end
-	
+
 	return profiles
 end
 
@@ -280,11 +280,11 @@ function OptionsHandlerPrototype:GetCurrentProfile()
 	return self.db:GetCurrentProfile()
 end
 
---[[ 
+--[[
 	List all active profiles
 	you can control the output with the .arg variable
 	currently four modes are supported
-	
+
 	(empty) - return all available profiles
 	"nocurrent" - returns all available profiles except the currently active profile
 	"common" - returns all avaialble profiles + some commonly used profiles ("char - realm", "realm", "class", "Default")
@@ -302,7 +302,7 @@ function OptionsHandlerPrototype:ListProfiles(info)
 	else
 		profiles = getProfileList(self.db)
 	end
-	
+
 	return profiles
 end
 
@@ -336,19 +336,19 @@ local function getOptionsHandler(db, noDefaultProfiles)
 	if not defaultProfiles then
 		generateDefaultProfiles(db)
 	end
-	
+
 	local handler = AceDBOptions.handlers[db] or { db = db, noDefaultProfiles = noDefaultProfiles }
-	
+
 	for k,v in pairs(OptionsHandlerPrototype) do
 		handler[k] = v
 	end
-	
+
 	AceDBOptions.handlers[db] = handler
 	return handler
 end
 
 --[[
-	the real options table 
+	the real options table
 ]]
 local optionsTable = {
 	desc = {
@@ -436,7 +436,7 @@ local optionsTable = {
 --- Get/Create a option table that you can use in your addon to control the profiles of AceDB-3.0.
 -- @param db The database object to create the options table for.
 -- @return The options table to be used in AceConfig-3.0
--- @usage 
+-- @usage
 -- -- Assuming `options` is your top-level options table and `self.db` is your database:
 -- options.args.profiles = LibStub("AceDBOptions-3.0"):GetOptionsTable(self.db)
 function AceDBOptions:GetOptionsTable(db, noDefaultProfiles)
@@ -445,7 +445,7 @@ function AceDBOptions:GetOptionsTable(db, noDefaultProfiles)
 			name = L["profiles"],
 			desc = L["profiles_sub"],
 		}
-	
+
 	tbl.handler = getOptionsHandler(db, noDefaultProfiles)
 	tbl.args = optionsTable
 

--- a/Libs/AceEvent-3.0/AceEvent-3.0.lua
+++ b/Libs/AceEvent-3.0/AceEvent-3.0.lua
@@ -2,14 +2,14 @@
 -- All dispatching is done using **CallbackHandler-1.0**. AceEvent is a simple wrapper around
 -- CallbackHandler, and dispatches all game events or addon message to the registrees.
 --
--- **AceEvent-3.0** can be embeded into your addon, either explicitly by calling AceEvent:Embed(MyAddon) or by 
+-- **AceEvent-3.0** can be embeded into your addon, either explicitly by calling AceEvent:Embed(MyAddon) or by
 -- specifying it as an embeded library in your AceAddon. All functions will be available on your addon object
 -- and can be accessed directly, without having to explicitly call AceEvent itself.\\
 -- It is recommended to embed AceEvent, otherwise you'll have to specify a custom `self` on all calls you
 -- make into AceEvent.
 -- @class file
 -- @name AceEvent-3.0
--- @release $Id: AceEvent-3.0.lua 1161 2017-08-12 14:30:16Z funkydude $
+-- @release $Id: AceEvent-3.0.lua 1202 2019-05-15 23:11:22Z nevcairiel $
 local CallbackHandler = LibStub("CallbackHandler-1.0")
 
 local MAJOR, MINOR = "AceEvent-3.0", 4
@@ -25,22 +25,22 @@ AceEvent.embeds = AceEvent.embeds or {} -- what objects embed this lib
 
 -- APIs and registry for blizzard events, using CallbackHandler lib
 if not AceEvent.events then
-	AceEvent.events = CallbackHandler:New(AceEvent, 
+	AceEvent.events = CallbackHandler:New(AceEvent,
 		"RegisterEvent", "UnregisterEvent", "UnregisterAllEvents")
 end
 
-function AceEvent.events:OnUsed(target, eventname) 
+function AceEvent.events:OnUsed(target, eventname)
 	AceEvent.frame:RegisterEvent(eventname)
 end
 
-function AceEvent.events:OnUnused(target, eventname) 
+function AceEvent.events:OnUnused(target, eventname)
 	AceEvent.frame:UnregisterEvent(eventname)
 end
 
 
 -- APIs and registry for IPC messages, using CallbackHandler lib
 if not AceEvent.messages then
-	AceEvent.messages = CallbackHandler:New(AceEvent, 
+	AceEvent.messages = CallbackHandler:New(AceEvent,
 		"RegisterMessage", "UnregisterMessage", "UnregisterAllMessages"
 	)
 	AceEvent.SendMessage = AceEvent.messages.Fire

--- a/Libs/AceGUI-3.0/AceGUI-3.0.lua
+++ b/Libs/AceGUI-3.0/AceGUI-3.0.lua
@@ -1,6 +1,6 @@
 --- **AceGUI-3.0** provides access to numerous widgets which can be used to create GUIs.
 -- AceGUI is used by AceConfigDialog to create the option GUIs, but you can use it by itself
--- to create any custom GUI. There are more extensive examples in the test suite in the Ace3 
+-- to create any custom GUI. There are more extensive examples in the test suite in the Ace3
 -- stand-alone distribution.
 --
 -- **Note**: When using AceGUI-3.0 directly, please do not modify the frames of the widgets directly,
@@ -24,14 +24,14 @@
 -- f:AddChild(btn)
 -- @class file
 -- @name AceGUI-3.0
--- @release $Id: AceGUI-3.0.lua 1193 2018-08-02 12:24:37Z funkydude $
-local ACEGUI_MAJOR, ACEGUI_MINOR = "AceGUI-3.0", 36
+-- @release $Id: AceGUI-3.0.lua 1247 2021-01-23 23:16:39Z funkehdude $
+local ACEGUI_MAJOR, ACEGUI_MINOR = "AceGUI-3.0", 41
 local AceGUI, oldminor = LibStub:NewLibrary(ACEGUI_MAJOR, ACEGUI_MINOR)
 
 if not AceGUI then return end -- No upgrade needed
 
 -- Lua APIs
-local tinsert = table.insert
+local tinsert, wipe = table.insert, table.wipe
 local select, pairs, next, type = select, pairs, next, type
 local error, assert = error, assert
 local setmetatable, rawget = setmetatable, rawget
@@ -51,7 +51,8 @@ AceGUI.LayoutRegistry = AceGUI.LayoutRegistry or {}
 AceGUI.WidgetBase = AceGUI.WidgetBase or {}
 AceGUI.WidgetContainerBase = AceGUI.WidgetContainerBase or {}
 AceGUI.WidgetVersions = AceGUI.WidgetVersions or {}
- 
+AceGUI.tooltip = AceGUI.tooltip or CreateFrame("GameTooltip", "AceGUITooltip", UIParent, "GameTooltipTemplate")
+
 -- local upvalues
 local WidgetRegistry = AceGUI.WidgetRegistry
 local LayoutRegistry = AceGUI.LayoutRegistry
@@ -79,7 +80,7 @@ do
 	-- Internal Storage of the objects changed, from an array table
 	-- to a hash table, and additionally we introduced versioning on
 	-- the widgets which would discard all widgets from a pre-29 version
-	-- anyway, so we just clear the storage now, and don't try to 
+	-- anyway, so we just clear the storage now, and don't try to
 	-- convert the storage tables to the new format.
 	-- This should generally not cause *many* widgets to end up in trash,
 	-- since once dialogs are opened, all addons should be loaded already
@@ -89,7 +90,7 @@ do
 	if oldminor and oldminor < 29 and AceGUI.objPools then
 		AceGUI.objPools = nil
 	end
-	
+
 	AceGUI.objPools = AceGUI.objPools or {}
 	local objPools = AceGUI.objPools
 	--Returns a new instance, if none are available either returns a new table or calls the given contructor
@@ -97,11 +98,11 @@ do
 		if not WidgetRegistry[type] then
 			error("Attempt to instantiate unknown widget type", 2)
 		end
-		
+
 		if not objPools[type] then
 			objPools[type] = {}
 		end
-		
+
 		local newObj = next(objPools[type])
 		if not newObj then
 			newObj = WidgetRegistry[type]()
@@ -151,12 +152,12 @@ function AceGUI:Create(type)
 			widget.OnAcquire = widget.Aquire
 			widget.Aquire = nil
 		end
-		
+
 		if rawget(widget, "Release") then
-			widget.OnRelease = rawget(widget, "Release") 
+			widget.OnRelease = rawget(widget, "Release")
 			widget.Release = nil
 		end
-		
+
 		if widget.OnAcquire then
 			widget:OnAcquire()
 		else
@@ -175,7 +176,10 @@ end
 -- If this widget is a Container-Widget, all of its Child-Widgets will be releases as well.
 -- @param widget The widget to release
 function AceGUI:Release(widget)
+	if widget.isQueuedForRelease then return end
+	widget.isQueuedForRelease = true
 	safecall(widget.PauseLayout, widget)
+	widget.frame:Hide()
 	widget:Fire("OnRelease")
 	safecall(widget.ReleaseChildren, widget)
 
@@ -204,7 +208,24 @@ function AceGUI:Release(widget)
 		widget.content.width = nil
 		widget.content.height = nil
 	end
+	widget.isQueuedForRelease = nil
 	delWidget(widget, widget.type)
+end
+
+--- Check if a widget is currently in the process of being released
+-- This function check if this widget, or any of its parents (in which case it'll be released shortly as well)
+-- are currently being released. This allows addon to handle any callbacks accordingly.
+-- @param widget The widget to check
+function AceGUI:IsReleasing(widget)
+	if widget.isQueuedForRelease then
+		return true
+	end
+
+	if widget.parent and widget.parent.AceGUIWidgetVersion then
+		return AceGUI:IsReleasing(widget.parent)
+	end
+
+	return false
 end
 
 -----------
@@ -238,18 +259,18 @@ end
 --[[
 	Widgets must provide the following functions
 		OnAcquire() - Called when the object is acquired, should set everything to a default hidden state
-		
+
 	And the following members
 		frame - the frame or derivitive object that will be treated as the widget for size and anchoring purposes
 		type - the type of the object, same as the name given to :RegisterWidget()
-		
+
 	Widgets contain a table called userdata, this is a safe place to store data associated with the wigdet
 	It will be cleared automatically when a widget is released
 	Placing values directly into a widget object should be avoided
-	
+
 	If the Widget can act as a container for other Widgets the following
 		content - frame or derivitive that children will be anchored to
-		
+
 	The Widget can supply the following Optional Members
 		:OnRelease() - Called when the object is Released, should remove any additional anchors and clear any data
 		:OnWidthSet(width) - Called when the width of the widget is changed
@@ -265,21 +286,21 @@ end
 -- Widget Base Template --
 --------------------------
 do
-	local WidgetBase = AceGUI.WidgetBase 
-	
+	local WidgetBase = AceGUI.WidgetBase
+
 	WidgetBase.SetParent = function(self, parent)
 		local frame = self.frame
 		frame:SetParent(nil)
 		frame:SetParent(parent.content)
 		self.parent = parent
 	end
-	
+
 	WidgetBase.SetCallback = function(self, name, func)
 		if type(func) == "function" then
 			self.events[name] = func
 		end
 	end
-	
+
 	WidgetBase.Fire = function(self, name, ...)
 		if self.events[name] then
 			local success, ret = safecall(self.events[name], self, name, ...)
@@ -288,7 +309,7 @@ do
 			end
 		end
 	end
-	
+
 	WidgetBase.SetWidth = function(self, width)
 		self.frame:SetWidth(width)
 		self.frame.width = width
@@ -296,7 +317,7 @@ do
 			self:OnWidthSet(width)
 		end
 	end
-	
+
 	WidgetBase.SetRelativeWidth = function(self, width)
 		if width <= 0 or width > 1 then
 			error(":SetRelativeWidth(width): Invalid relative width.", 2)
@@ -304,7 +325,7 @@ do
 		self.relWidth = width
 		self.width = "relative"
 	end
-	
+
 	WidgetBase.SetHeight = function(self, height)
 		self.frame:SetHeight(height)
 		self.frame.height = height
@@ -312,7 +333,7 @@ do
 			self:OnHeightSet(height)
 		end
 	end
-	
+
 	--[[ WidgetBase.SetRelativeHeight = function(self, height)
 		if height <= 0 or height > 1 then
 			error(":SetRelativeHeight(height): Invalid relative height.", 2)
@@ -324,47 +345,51 @@ do
 	WidgetBase.IsVisible = function(self)
 		return self.frame:IsVisible()
 	end
-	
+
 	WidgetBase.IsShown= function(self)
 		return self.frame:IsShown()
 	end
-		
+
 	WidgetBase.Release = function(self)
 		AceGUI:Release(self)
 	end
-	
+
+	WidgetBase.IsReleasing = function(self)
+		return AceGUI:IsReleasing(self)
+	end
+
 	WidgetBase.SetPoint = function(self, ...)
 		return self.frame:SetPoint(...)
 	end
-	
+
 	WidgetBase.ClearAllPoints = function(self)
 		return self.frame:ClearAllPoints()
 	end
-	
+
 	WidgetBase.GetNumPoints = function(self)
 		return self.frame:GetNumPoints()
 	end
-	
+
 	WidgetBase.GetPoint = function(self, ...)
 		return self.frame:GetPoint(...)
-	end	
-	
+	end
+
 	WidgetBase.GetUserDataTable = function(self)
 		return self.userdata
 	end
-	
+
 	WidgetBase.SetUserData = function(self, key, value)
 		self.userdata[key] = value
 	end
-	
+
 	WidgetBase.GetUserData = function(self, key)
 		return self.userdata[key]
 	end
-	
+
 	WidgetBase.IsFullHeight = function(self)
 		return self.height == "fill"
 	end
-	
+
 	WidgetBase.SetFullHeight = function(self, isFull)
 		if isFull then
 			self.height = "fill"
@@ -372,11 +397,11 @@ do
 			self.height = nil
 		end
 	end
-	
+
 	WidgetBase.IsFullWidth = function(self)
 		return self.width == "fill"
 	end
-		
+
 	WidgetBase.SetFullWidth = function(self, isFull)
 		if isFull then
 			self.width = "fill"
@@ -384,29 +409,29 @@ do
 			self.width = nil
 		end
 	end
-	
+
 --	local function LayoutOnUpdate(this)
 --		this:SetScript("OnUpdate",nil)
 --		this.obj:PerformLayout()
 --	end
-	
+
 	local WidgetContainerBase = AceGUI.WidgetContainerBase
-		
+
 	WidgetContainerBase.PauseLayout = function(self)
 		self.LayoutPaused = true
 	end
-	
+
 	WidgetContainerBase.ResumeLayout = function(self)
 		self.LayoutPaused = nil
 	end
-	
+
 	WidgetContainerBase.PerformLayout = function(self)
 		if self.LayoutPaused then
 			return
 		end
 		safecall(self.LayoutFunc, self.content, self.children)
 	end
-	
+
 	--call this function to layout, makes sure layed out objects get a frame to get sizes etc
 	WidgetContainerBase.DoLayout = function(self)
 		self:PerformLayout()
@@ -414,7 +439,7 @@ do
 --			self.frame:SetScript("OnUpdate", LayoutOnUpdate)
 --		end
 	end
-	
+
 	WidgetContainerBase.AddChild = function(self, child, beforeWidget)
 		if beforeWidget then
 			local siblingIndex = 1
@@ -422,7 +447,7 @@ do
 				if widget == beforeWidget then
 					break
 				end
-				siblingIndex = siblingIndex + 1 
+				siblingIndex = siblingIndex + 1
 			end
 			tinsert(self.children, siblingIndex, child)
 		else
@@ -432,7 +457,7 @@ do
 		child.frame:Show()
 		self:DoLayout()
 	end
-	
+
 	WidgetContainerBase.AddChildren = function(self, ...)
 		for i = 1, select("#", ...) do
 			local child = select(i, ...)
@@ -442,7 +467,7 @@ do
 		end
 		self:DoLayout()
 	end
-	
+
 	WidgetContainerBase.ReleaseChildren = function(self)
 		local children = self.children
 		for i = 1,#children do
@@ -450,7 +475,7 @@ do
 			children[i] = nil
 		end
 	end
-	
+
 	WidgetContainerBase.SetLayout = function(self, Layout)
 		self.LayoutFunc = AceGUI:GetLayout(Layout)
 	end
@@ -474,7 +499,7 @@ do
 			end
 		end
 	end
-	
+
 	local function ContentResize(this)
 		if this:GetWidth() and this:GetHeight() then
 			this.width = this:GetWidth()
@@ -486,7 +511,7 @@ do
 	setmetatable(WidgetContainerBase, {__index=WidgetBase})
 
 	--One of these function should be called on each Widget Instance as part of its creation process
-	
+
 	--- Register a widget-class as a container for newly created widgets.
 	-- @param widget The widget class
 	function AceGUI:RegisterAsContainer(widget)
@@ -502,7 +527,7 @@ do
 		widget:SetLayout("List")
 		return widget
 	end
-	
+
 	--- Register a widget-class as a widget.
 	-- @param widget The widget class
 	function AceGUI:RegisterAsWidget(widget)
@@ -529,11 +554,11 @@ end
 -- @param Version The version of the widget
 function AceGUI:RegisterWidgetType(Name, Constructor, Version)
 	assert(type(Constructor) == "function")
-	assert(type(Version) == "number") 
-	
+	assert(type(Version) == "number")
+
 	local oldVersion = WidgetVersions[Name]
 	if oldVersion and oldVersion >= Version then return end
-	
+
 	WidgetVersions[Name] = Version
 	WidgetRegistry[Name] = Constructor
 end
@@ -602,7 +627,7 @@ AceGUI:RegisterLayout("List",
 		local width = content.width or content:GetWidth() or 0
 		for i = 1, #children do
 			local child = children[i]
-			
+
 			local frame = child.frame
 			frame:ClearAllPoints()
 			frame:Show()
@@ -611,22 +636,22 @@ AceGUI:RegisterLayout("List",
 			else
 				frame:SetPoint("TOPLEFT", children[i-1].frame, "BOTTOMLEFT")
 			end
-			
+
 			if child.width == "fill" then
 				child:SetWidth(width)
 				frame:SetPoint("RIGHT", content)
-				
+
 				if child.DoLayout then
 					child:DoLayout()
 				end
 			elseif child.width == "relative" then
 				child:SetWidth(width * child.relWidth)
-				
+
 				if child.DoLayout then
 					child:DoLayout()
 				end
 			end
-			
+
 			height = height + (frame.height or frame:GetHeight() or 0)
 		end
 		safecall(content.obj.LayoutFinished, content.obj, nil, height)
@@ -638,6 +663,7 @@ AceGUI:RegisterLayout("Fill",
 		if children[1] then
 			children[1]:SetWidth(content:GetWidth() or 0)
 			children[1]:SetHeight(content:GetHeight() or 0)
+			children[1].frame:ClearAllPoints()
 			children[1].frame:SetAllPoints(content)
 			children[1].frame:Show()
 			safecall(content.obj.LayoutFinished, content.obj, nil, children[1].frame:GetHeight())
@@ -661,17 +687,17 @@ AceGUI:RegisterLayout("Flow",
 		--height of the current row
 		local rowheight = 0
 		local rowoffset = 0
-		
+
 		local width = content.width or content:GetWidth() or 0
-		
+
 		--control at the start of the row
 		local rowstart
 		local rowstartoffset
 		local isfullheight
-		
+
 		local frameoffset
 		local lastframeoffset
-		local oversize 
+		local oversize
 		for i = 1, #children do
 			local child = children[i]
 			oversize = nil
@@ -679,17 +705,17 @@ AceGUI:RegisterLayout("Flow",
 			local frameheight = frame.height or frame:GetHeight() or 0
 			local framewidth = frame.width or frame:GetWidth() or 0
 			lastframeoffset = frameoffset
-			-- HACK: Why did we set a frameoffset of (frameheight / 2) ? 
+			-- HACK: Why did we set a frameoffset of (frameheight / 2) ?
 			-- That was moving all widgets half the widgets size down, is that intended?
 			-- Actually, it seems to be neccessary for many cases, we'll leave it in for now.
 			-- If widgets seem to anchor weirdly with this, provide a valid alignoffset for them.
 			-- TODO: Investigate moar!
 			frameoffset = child.alignoffset or (frameheight / 2)
-			
+
 			if child.width == "relative" then
 				framewidth = width * child.relWidth
 			end
-			
+
 			frame:Show()
 			frame:ClearAllPoints()
 			if i == 1 then
@@ -728,11 +754,11 @@ AceGUI:RegisterLayout("Flow",
 				else
 					--handles cases where the new height is higher than either control because of the offsets
 					--math.max(rowheight-rowoffset+frameoffset, frameheight-frameoffset+rowoffset)
-					
+
 					--offset is always the larger of the two offsets
 					rowoffset = math_max(rowoffset, frameoffset)
 					rowheight = math_max(rowheight, rowoffset + (frameheight / 2))
-					
+
 					frame:SetPoint("TOPLEFT", children[i-1].frame, "TOPRIGHT", 0, frameoffset - lastframeoffset)
 					usedwidth = framewidth + usedwidth
 				end
@@ -741,11 +767,11 @@ AceGUI:RegisterLayout("Flow",
 			if child.width == "fill" then
 				safelayoutcall(child, "SetWidth", width)
 				frame:SetPoint("RIGHT", content)
-				
+
 				usedwidth = 0
 				rowstart = frame
 				rowstartoffset = frameoffset
-				
+
 				if child.DoLayout then
 					child:DoLayout()
 				end
@@ -754,7 +780,7 @@ AceGUI:RegisterLayout("Flow",
 				rowstartoffset = rowoffset
 			elseif child.width == "relative" then
 				safelayoutcall(child, "SetWidth", width * child.relWidth)
-				
+
 				if child.DoLayout then
 					child:DoLayout()
 				end
@@ -763,20 +789,20 @@ AceGUI:RegisterLayout("Flow",
 					frame:SetPoint("RIGHT", content)
 				end
 			end
-			
+
 			if child.height == "fill" then
 				frame:SetPoint("BOTTOM", content)
 				isfullheight = true
 			end
 		end
-		
+
 		--anchor the last row, if its full height needs a special case since  its height has just been changed by the anchor
 		if isfullheight then
 			rowstart:SetPoint("TOPLEFT", content, "TOPLEFT", 0, -height)
 		elseif rowstart then
 			rowstart:SetPoint("TOPLEFT", content, "TOPLEFT", 0, -(height + (rowoffset - rowstartoffset) + 3))
 		end
-		
+
 		height = height + rowheight + 3
 		safecall(content.obj.LayoutFinished, content.obj, nil, height)
 	end)
@@ -840,7 +866,7 @@ AceGUI:RegisterLayout("Table",
 		local spaceH = tableObj.spaceH or tableObj.space or 0
 		local spaceV = tableObj.spaceV or tableObj.space or 0
 		local totalH = (content:GetWidth() or content.width or 0) - spaceH * (#cols - 1)
-		
+
 		-- We need to reuse these because layout events can come in very frequently
 		local layoutCache = obj:GetUserData("layoutCache")
 		if not layoutCache then
@@ -848,7 +874,7 @@ AceGUI:RegisterLayout("Table",
 			obj:SetUserData("layoutCache", layoutCache)
 		end
 		local t, laneH, laneV, rowspans, rowStart, colStart = unpack(layoutCache)
-		
+
 		-- Create the grid
 		local n, slotFound = 0
 		for i,child in ipairs(children) do
@@ -913,7 +939,7 @@ AceGUI:RegisterLayout("Table",
 							local f = child.frame
 							f:ClearAllPoints()
 							local childH = f:GetWidth() or 0
-		
+
 							laneH[col] = max(laneH[col], childH - GetCellDimension("H", laneH, colStart[child], col - 1, spaceH))
 						end
 					end
@@ -947,7 +973,7 @@ AceGUI:RegisterLayout("Table",
 					local cellObj = child:GetUserData("cell")
 					local offsetH = GetCellDimension("H", laneH, 1, colStart[child] - 1, spaceH) + (colStart[child] == 1 and 0 or spaceH)
 					local cellH = GetCellDimension("H", laneH, colStart[child], col, spaceH)
-					
+
 					local f = child.frame
 					f:ClearAllPoints()
 					local childH = f:GetWidth() or 0
@@ -957,7 +983,7 @@ AceGUI:RegisterLayout("Table",
 					if child:IsFullWidth() or alignFn == "fill" or childH > cellH then
 						f:SetPoint("RIGHT", content, "LEFT", offsetH + align + cellH, 0)
 					end
-					
+
 					if child.DoLayout then
 						child:DoLayout()
 					end
@@ -976,7 +1002,7 @@ AceGUI:RegisterLayout("Table",
 					local cellObj = child:GetUserData("cell")
 					local offsetV = GetCellDimension("V", laneV, 1, rowStart[child] - 1, spaceV) + (rowStart[child] == 1 and 0 or spaceV)
 					local cellV = GetCellDimension("V", laneV, rowStart[child], row, spaceV)
-						
+
 					local f = child.frame
 					local childV = f:GetHeight() or 0
 
@@ -991,7 +1017,7 @@ AceGUI:RegisterLayout("Table",
 
 		-- Calculate total height
 		local totalV = GetCellDimension("V", laneV, 1, #laneV, spaceV)
-		
+
 		-- Cleanup
 		for _,v in pairs(layoutCache) do wipe(v) end
 

--- a/Libs/AceGUI-3.0/widgets/AceGUIContainer-BlizOptionsGroup.lua
+++ b/Libs/AceGUI-3.0/widgets/AceGUIContainer-BlizOptionsGroup.lua
@@ -2,7 +2,7 @@
 BlizOptionsGroup Container
 Simple container widget for the integration of AceGUI into the Blizzard Interface Options
 -------------------------------------------------------------------------------]]
-local Type, Version = "BlizOptionsGroup", 21
+local Type, Version = "BlizOptionsGroup", 22
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
 if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
 
@@ -99,7 +99,7 @@ local methods = {
 Constructor
 -------------------------------------------------------------------------------]]
 local function Constructor()
-	local frame = CreateFrame("Frame")
+	local frame = CreateFrame("Frame", nil, InterfaceOptionsFramePanelContainer)
 	frame:Hide()
 
 	-- support functions for the Blizzard Interface Options

--- a/Libs/AceGUI-3.0/widgets/AceGUIContainer-DropDownGroup.lua
+++ b/Libs/AceGUI-3.0/widgets/AceGUIContainer-DropDownGroup.lua
@@ -2,7 +2,7 @@
 DropdownGroup Container
 Container controlled by a dropdown on the top.
 -------------------------------------------------------------------------------]]
-local Type, Version = "DropdownGroup", 21
+local Type, Version = "DropdownGroup", 22
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
 if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
 
@@ -125,7 +125,7 @@ local function Constructor()
 	dropdown.frame:Show()
 	dropdown:SetLabel("")
 
-	local border = CreateFrame("Frame", nil, frame)
+	local border = CreateFrame("Frame", nil, frame, BackdropTemplateMixin and "BackdropTemplate" or nil)
 	border:SetPoint("TOPLEFT", 0, -26)
 	border:SetPoint("BOTTOMRIGHT", 0, 3)
 	border:SetBackdrop(PaneBackdrop)
@@ -150,7 +150,7 @@ local function Constructor()
 		widget[method] = func
 	end
 	dropdown.parentgroup = widget
-	
+
 	return AceGUI:RegisterAsContainer(widget)
 end
 

--- a/Libs/AceGUI-3.0/widgets/AceGUIContainer-Frame.lua
+++ b/Libs/AceGUI-3.0/widgets/AceGUIContainer-Frame.lua
@@ -1,7 +1,7 @@
 --[[-----------------------------------------------------------------------------
 Frame Container
 -------------------------------------------------------------------------------]]
-local Type, Version = "Frame", 26
+local Type, Version = "Frame", 28
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
 if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
 
@@ -83,6 +83,7 @@ local methods = {
 	["OnAcquire"] = function(self)
 		self.frame:SetParent(UIParent)
 		self.frame:SetFrameStrata("FULLSCREEN_DIALOG")
+		self.frame:SetFrameLevel(100) -- Lots of room to draw under it
 		self:SetTitle()
 		self:SetStatusText()
 		self:ApplyStatus()
@@ -179,13 +180,14 @@ local PaneBackdrop  = {
 }
 
 local function Constructor()
-	local frame = CreateFrame("Frame", nil, UIParent)
+	local frame = CreateFrame("Frame", nil, UIParent, BackdropTemplateMixin and "BackdropTemplate" or nil)
 	frame:Hide()
 
 	frame:EnableMouse(true)
 	frame:SetMovable(true)
 	frame:SetResizable(true)
 	frame:SetFrameStrata("FULLSCREEN_DIALOG")
+	frame:SetFrameLevel(100) -- Lots of room to draw under it
 	frame:SetBackdrop(FrameBackdrop)
 	frame:SetBackdropColor(0, 0, 0, 1)
 	frame:SetMinResize(400, 200)
@@ -201,7 +203,7 @@ local function Constructor()
 	closebutton:SetWidth(100)
 	closebutton:SetText(CLOSE)
 
-	local statusbg = CreateFrame("Button", nil, frame)
+	local statusbg = CreateFrame("Button", nil, frame, BackdropTemplateMixin and "BackdropTemplate" or nil)
 	statusbg:SetPoint("BOTTOMLEFT", 15, 15)
 	statusbg:SetPoint("BOTTOMRIGHT", -132, 15)
 	statusbg:SetHeight(24)

--- a/Libs/AceGUI-3.0/widgets/AceGUIContainer-InlineGroup.lua
+++ b/Libs/AceGUI-3.0/widgets/AceGUIContainer-InlineGroup.lua
@@ -2,7 +2,7 @@
 InlineGroup Container
 Simple container widget that creates a visible "box" with an optional title.
 -------------------------------------------------------------------------------]]
-local Type, Version = "InlineGroup", 21
+local Type, Version = "InlineGroup", 22
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
 if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
 
@@ -75,7 +75,7 @@ local function Constructor()
 	titletext:SetJustifyH("LEFT")
 	titletext:SetHeight(18)
 
-	local border = CreateFrame("Frame", nil, frame)
+	local border = CreateFrame("Frame", nil, frame, BackdropTemplateMixin and "BackdropTemplate" or nil)
 	border:SetPoint("TOPLEFT", 0, -17)
 	border:SetPoint("BOTTOMRIGHT", -1, 3)
 	border:SetBackdrop(PaneBackdrop)

--- a/Libs/AceGUI-3.0/widgets/AceGUIContainer-ScrollFrame.lua
+++ b/Libs/AceGUI-3.0/widgets/AceGUIContainer-ScrollFrame.lua
@@ -40,7 +40,7 @@ end
 Methods
 -------------------------------------------------------------------------------]]
 local methods = {
-	["OnAcquire"] = function(self) 
+	["OnAcquire"] = function(self)
 		self:SetScroll(0)
 		self.scrollframe:SetScript("OnUpdate", FixScrollOnUpdate)
 	end,
@@ -77,7 +77,7 @@ local methods = {
 	["MoveScroll"] = function(self, value)
 		local status = self.status or self.localstatus
 		local height, viewheight = self.scrollframe:GetHeight(), self.content:GetHeight()
-		
+
 		if self.scrollBarShown then
 			local diff = height - viewheight
 			local delta = 1

--- a/Libs/AceGUI-3.0/widgets/AceGUIContainer-TabGroup.lua
+++ b/Libs/AceGUI-3.0/widgets/AceGUIContainer-TabGroup.lua
@@ -2,12 +2,12 @@
 TabGroup Container
 Container that uses tabs on top to switch between groups.
 -------------------------------------------------------------------------------]]
-local Type, Version = "TabGroup", 36
+local Type, Version = "TabGroup", 37
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
 if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
 
 -- Lua APIs
-local pairs, ipairs, assert, type, wipe = pairs, ipairs, assert, type, wipe
+local pairs, ipairs, assert, type, wipe = pairs, ipairs, assert, type, table.wipe
 
 -- WoW APIs
 local PlaySound = PlaySound
@@ -161,21 +161,21 @@ local methods = {
 		self.tablist = tabs
 		self:BuildTabs()
 	end,
-	
+
 
 	["BuildTabs"] = function(self)
 		local hastitle = (self.titletext:GetText() and self.titletext:GetText() ~= "")
 		local tablist = self.tablist
 		local tabs = self.tabs
-		
+
 		if not tablist then return end
-		
+
 		local width = self.frame.width or self.frame:GetWidth() or 0
-		
+
 		wipe(widths)
 		wipe(rowwidths)
 		wipe(rowends)
-		
+
 		--Place Text into tabs and get thier initial width
 		for i, v in ipairs(tablist) do
 			local tab = tabs[i]
@@ -183,19 +183,19 @@ local methods = {
 				tab = self:CreateTab(i)
 				tabs[i] = tab
 			end
-			
+
 			tab:Show()
 			tab:SetText(v.text)
 			tab:SetDisabled(v.disabled)
 			tab.value = v.value
-			
+
 			widths[i] = tab:GetWidth() - 6 --tabs are anchored 10 pixels from the right side of the previous one to reduce spacing, but add a fixed 4px padding for the text
 		end
-		
+
 		for i = (#tablist)+1, #tabs, 1 do
 			tabs[i]:Hide()
 		end
-		
+
 		--First pass, find the minimum number of rows needed to hold all tabs and the initial tab layout
 		local numtabs = #tablist
 		local numrows = 1
@@ -213,7 +213,7 @@ local methods = {
 		end
 		rowwidths[numrows] = usedwidth + 10 --first tab in each row takes up an extra 10px
 		rowends[numrows] = #tablist
-		
+
 		--Fix for single tabs being left on the last row, move a tab from the row above if applicable
 		if numrows > 1 then
 			--if the last row has only one tab
@@ -244,22 +244,22 @@ local methods = {
 					tab:SetPoint("LEFT", tabs[tabno-1], "RIGHT", -10, 0)
 				end
 			end
-			
+
 			-- equal padding for each tab to fill the available width,
 			-- if the used space is above 75% already
-			-- the 18 pixel is the typical width of a scrollbar, so we can have a tab group inside a scrolling frame, 
+			-- the 18 pixel is the typical width of a scrollbar, so we can have a tab group inside a scrolling frame,
 			-- and not have the tabs jump around funny when switching between tabs that need scrolling and those that don't
 			local padding = 0
 			if not (numrows == 1 and rowwidths[1] < width*0.75 - 18) then
 				padding = (width - rowwidths[row]) / (endtab - starttab+1)
 			end
-			
+
 			for i = starttab, endtab do
 				PanelTemplates_TabResize(tabs[i], padding + 4, nil, nil, width, tabs[i]:GetFontString():GetStringWidth())
 			end
 			starttab = endtab + 1
 		end
-		
+
 		self.borderoffset = (hastitle and 17 or 10)+((numrows)*20)
 		self.border:SetPoint("TOPLEFT", 1, -self.borderoffset)
 	end,
@@ -285,7 +285,7 @@ local methods = {
 		content:SetHeight(contentheight)
 		content.height = contentheight
 	end,
-	
+
 	["LayoutFinished"] = function(self, width, height)
 		if self.noAutoHeight then return end
 		self:SetHeight((height or 0) + (self.borderoffset + 23))
@@ -316,7 +316,7 @@ local function Constructor()
 	titletext:SetHeight(18)
 	titletext:SetText("")
 
-	local border = CreateFrame("Frame", nil, frame)
+	local border = CreateFrame("Frame", nil, frame, BackdropTemplateMixin and "BackdropTemplate" or nil)
 	border:SetPoint("TOPLEFT", 1, -27)
 	border:SetPoint("BOTTOMRIGHT", -1, 3)
 	border:SetBackdrop(PaneBackdrop)
@@ -342,7 +342,7 @@ local function Constructor()
 	for method, func in pairs(methods) do
 		widget[method] = func
 	end
-	
+
 	return AceGUI:RegisterAsContainer(widget)
 end
 

--- a/Libs/AceGUI-3.0/widgets/AceGUIContainer-TreeGroup.lua
+++ b/Libs/AceGUI-3.0/widgets/AceGUIContainer-TreeGroup.lua
@@ -2,11 +2,9 @@
 TreeGroup Container
 Container that uses a tree control to switch between groups.
 -------------------------------------------------------------------------------]]
-local Type, Version = "TreeGroup", 41
+local Type, Version = "TreeGroup", 45
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
 if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
-
-local WoW80 = select(4, GetBuildInfo()) >= 80000
 
 -- Lua APIs
 local next, pairs, ipairs, assert, type = next, pairs, ipairs, assert, type
@@ -18,7 +16,7 @@ local CreateFrame, UIParent = CreateFrame, UIParent
 
 -- Global vars/functions that we don't upvalue since they might get hooked, or upgraded
 -- List them here for Mikk's FindGlobals script
--- GLOBALS: GameTooltip, FONT_COLOR_CODE_CLOSE
+-- GLOBALS: FONT_COLOR_CODE_CLOSE
 
 -- Recycling functions
 local new, del
@@ -36,7 +34,7 @@ do
 	function del(t)
 		for k in pairs(t) do
 			t[k] = nil
-		end	
+		end
 		pool[t] = true
 	end
 end
@@ -66,7 +64,7 @@ local function UpdateButton(button, treeline, selected, canExpand, isExpanded)
 	local value = treeline.value
 	local uniquevalue = treeline.uniquevalue
 	local disabled = treeline.disabled
-	
+
 	button.treeline = treeline
 	button.value = value
 	button.uniquevalue = uniquevalue
@@ -87,7 +85,7 @@ local function UpdateButton(button, treeline, selected, canExpand, isExpanded)
 		button:SetHighlightFontObject("GameFontHighlightSmall")
 		button.text:SetPoint("LEFT", (icon and 16 or 0) + 8 * level, 2)
 	end
-	
+
 	if disabled then
 		button:EnableMouse(false)
 		button.text:SetText("|cff808080"..text..FONT_COLOR_CODE_CLOSE)
@@ -95,20 +93,20 @@ local function UpdateButton(button, treeline, selected, canExpand, isExpanded)
 		button.text:SetText(text)
 		button:EnableMouse(true)
 	end
-	
+
 	if icon then
 		button.icon:SetTexture(icon)
 		button.icon:SetPoint("LEFT", 8 * level, (level == 1) and 0 or 1)
 	else
 		button.icon:SetTexture(nil)
 	end
-	
+
 	if iconCoords then
 		button.icon:SetTexCoord(unpack(iconCoords))
 	else
 		button.icon:SetTexCoord(0, 1, 0, 1)
 	end
-	
+
 	if canExpand then
 		if not isExpanded then
 			toggle:SetNormalTexture(130838) -- Interface\\Buttons\\UI-PlusButton-UP
@@ -208,11 +206,13 @@ local function Button_OnEnter(frame)
 	self:Fire("OnButtonEnter", frame.uniquevalue, frame)
 
 	if self.enabletooltips then
-		GameTooltip:SetOwner(frame, "ANCHOR_NONE")
-		GameTooltip:SetPoint("LEFT",frame,"RIGHT")
-		GameTooltip:SetText(frame.text:GetText() or "", 1, .82, 0, true)
+		local tooltip = AceGUI.tooltip
+		tooltip:SetOwner(frame, "ANCHOR_NONE")
+		tooltip:ClearAllPoints()
+		tooltip:SetPoint("LEFT",frame,"RIGHT")
+		tooltip:SetText(frame.text:GetText() or "", 1, .82, 0, true)
 
-		GameTooltip:Show()
+		tooltip:Show()
 	end
 end
 
@@ -221,7 +221,7 @@ local function Button_OnLeave(frame)
 	self:Fire("OnButtonLeave", frame.uniquevalue, frame)
 
 	if self.enabletooltips then
-		GameTooltip:Hide()
+		AceGUI.tooltip:Hide()
 	end
 end
 
@@ -267,18 +267,19 @@ end
 local function Dragger_OnMouseUp(frame)
 	local treeframe = frame:GetParent()
 	local self = treeframe.obj
-	local frame = treeframe:GetParent()
+	local treeframeParent = treeframe:GetParent()
 	treeframe:StopMovingOrSizing()
 	--treeframe:SetScript("OnUpdate", nil)
 	treeframe:SetUserPlaced(false)
 	--Without this :GetHeight will get stuck on the current height, causing the tree contents to not resize
 	treeframe:SetHeight(0)
-	treeframe:SetPoint("TOPLEFT", frame, "TOPLEFT",0,0)
-	treeframe:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT",0,0)
-	
+	treeframe:ClearAllPoints()
+	treeframe:SetPoint("TOPLEFT", treeframeParent, "TOPLEFT",0,0)
+	treeframe:SetPoint("BOTTOMLEFT", treeframeParent, "BOTTOMLEFT",0,0)
+
 	local status = self.status or self.localstatus
 	status.treewidth = treeframe:GetWidth()
-	
+
 	treeframe.obj:Fire("OnTreeResize",treeframe:GetWidth())
 	-- recalculate the content width
 	treeframe.obj:OnWidthSet(status.fullwidth)
@@ -363,8 +364,8 @@ local methods = {
 	--sets the tree to be displayed
 	["SetTree"] = function(self, tree, filter)
 		self.filter = filter
-		if tree then 
-			assert(type(tree) == "table") 
+		if tree then
+			assert(type(tree) == "table")
 		end
 		self.tree = tree
 		self:RefreshTree()
@@ -372,7 +373,7 @@ local methods = {
 
 	["BuildLevel"] = function(self, tree, level, parent)
 		local groups = (self.status or self.localstatus).groups
-		
+
 		for i, v in ipairs(tree) do
 			if v.children then
 				if not self.filter or ShouldDisplayLevel(v.children) then
@@ -409,7 +410,7 @@ local methods = {
 		local tree = self.tree
 
 		local treeframe = self.treeframe
-		
+
 		status.scrollToSelection = status.scrollToSelection or scrollToSelection	-- needs to be cached in case the control hasn't been drawn yet (code bails out below)
 
 		self:BuildLevel(tree, 1)
@@ -419,14 +420,13 @@ local methods = {
 		local maxlines = (floor(((self.treeframe:GetHeight()or 0) - 20 ) / 18))
 		if maxlines <= 0 then return end
 
-		-- workaround for lag spikes on WoW 8.0
-		if WoW80 and self.frame:GetParent() == UIParent and not fromOnUpdate then
+		if self.frame:GetParent() == UIParent and not fromOnUpdate then
 			self.frame:SetScript("OnUpdate", FirstFrameUpdate)
 			return
 		end
 
 		local first, last
-		
+
 		scrollToSelection = status.scrollToSelection
 		status.scrollToSelection = nil
 
@@ -502,9 +502,9 @@ local methods = {
 			button:Show()
 			buttonnum = buttonnum + 1
 		end
-		
+
 	end,
-	
+
 	["SetSelected"] = function(self, value)
 		local status = self.status or self.localstatus
 		if status.selected ~= value then
@@ -554,16 +554,16 @@ local methods = {
 		local treeframe = self.treeframe
 		local status = self.status or self.localstatus
 		status.fullwidth = width
-		
+
 		local contentwidth = width - status.treewidth - 20
 		if contentwidth < 0 then
 			contentwidth = 0
 		end
 		content:SetWidth(contentwidth)
 		content.width = contentwidth
-		
+
 		local maxtreewidth = math_min(400, width - 50)
-		
+
 		if maxtreewidth > 100 and status.treewidth > maxtreewidth then
 			self:SetTreeWidth(maxtreewidth, status.treesizable)
 		end
@@ -589,16 +589,16 @@ local methods = {
 				treewidth = DEFAULT_TREE_WIDTH
 			else
 				resizable = false
-				treewidth = DEFAULT_TREE_WIDTH 
+				treewidth = DEFAULT_TREE_WIDTH
 			end
 		end
 		self.treeframe:SetWidth(treewidth)
 		self.dragger:EnableMouse(resizable)
-		
+
 		local status = self.status or self.localstatus
 		status.treewidth = treewidth
 		status.treesizable = resizable
-		
+
 		-- recalculate the content width
 		if status.fullwidth then
 			self:OnWidthSet(status.fullwidth)
@@ -629,7 +629,7 @@ local PaneBackdrop  = {
 local DraggerBackdrop  = {
 	bgFile = "Interface\\Tooltips\\UI-Tooltip-Background",
 	edgeFile = nil,
-	tile = true, tileSize = 16, edgeSize = 0,
+	tile = true, tileSize = 16, edgeSize = 1,
 	insets = { left = 3, right = 3, top = 7, bottom = 7 }
 }
 
@@ -637,7 +637,7 @@ local function Constructor()
 	local num = AceGUI:GetNextWidgetNum(Type)
 	local frame = CreateFrame("Frame", nil, UIParent)
 
-	local treeframe = CreateFrame("Frame", nil, frame)
+	local treeframe = CreateFrame("Frame", nil, frame, BackdropTemplateMixin and "BackdropTemplate" or nil)
 	treeframe:SetPoint("TOPLEFT")
 	treeframe:SetPoint("BOTTOMLEFT")
 	treeframe:SetWidth(DEFAULT_TREE_WIDTH)
@@ -652,7 +652,7 @@ local function Constructor()
 	treeframe:SetScript("OnSizeChanged", Tree_OnSizeChanged)
 	treeframe:SetScript("OnMouseWheel", Tree_OnMouseWheel)
 
-	local dragger = CreateFrame("Frame", nil, treeframe)
+	local dragger = CreateFrame("Frame", nil, treeframe, BackdropTemplateMixin and "BackdropTemplate" or nil)
 	dragger:SetWidth(8)
 	dragger:SetPoint("TOP", treeframe, "TOPRIGHT")
 	dragger:SetPoint("BOTTOM", treeframe, "BOTTOMRIGHT")
@@ -677,7 +677,7 @@ local function Constructor()
 	scrollbg:SetAllPoints(scrollbar)
 	scrollbg:SetColorTexture(0,0,0,0.4)
 
-	local border = CreateFrame("Frame",nil,frame)
+	local border = CreateFrame("Frame", nil, frame, BackdropTemplateMixin and "BackdropTemplate" or nil)
 	border:SetPoint("TOPLEFT", treeframe, "TOPRIGHT")
 	border:SetPoint("BOTTOMRIGHT")
 	border:SetBackdrop(PaneBackdrop)

--- a/Libs/AceGUI-3.0/widgets/AceGUIContainer-Window.lua
+++ b/Libs/AceGUI-3.0/widgets/AceGUIContainer-Window.lua
@@ -30,21 +30,21 @@ do
 	local function frameOnClose(this)
 		this.obj:Fire("OnClose")
 	end
-	
+
 	local function closeOnClick(this)
 		PlaySound(799) -- SOUNDKIT.GS_TITLE_OPTION_EXIT
 		this.obj:Hide()
 	end
-	
+
 	local function frameOnMouseDown(this)
 		AceGUI:ClearFocus()
 	end
-	
+
 	local function titleOnMouseDown(this)
 		this:GetParent():StartMoving()
 		AceGUI:ClearFocus()
 	end
-	
+
 	local function frameOnMouseUp(this)
 		local frame = this:GetParent()
 		frame:StopMovingOrSizing()
@@ -55,22 +55,22 @@ do
 		status.top = frame:GetTop()
 		status.left = frame:GetLeft()
 	end
-	
+
 	local function sizerseOnMouseDown(this)
 		this:GetParent():StartSizing("BOTTOMRIGHT")
 		AceGUI:ClearFocus()
 	end
-	
+
 	local function sizersOnMouseDown(this)
 		this:GetParent():StartSizing("BOTTOM")
 		AceGUI:ClearFocus()
 	end
-	
+
 	local function sizereOnMouseDown(this)
 		this:GetParent():StartSizing("RIGHT")
 		AceGUI:ClearFocus()
 	end
-	
+
 	local function sizerOnMouseUp(this)
 		this:GetParent():StopMovingOrSizing()
 	end
@@ -78,19 +78,19 @@ do
 	local function SetTitle(self,title)
 		self.titletext:SetText(title)
 	end
-	
+
 	local function SetStatusText(self,text)
 		-- self.statustext:SetText(text)
 	end
-	
+
 	local function Hide(self)
 		self.frame:Hide()
 	end
-	
+
 	local function Show(self)
 		self.frame:Show()
 	end
-	
+
 	local function OnAcquire(self)
 		self.frame:SetParent(UIParent)
 		self.frame:SetFrameStrata("FULLSCREEN_DIALOG")
@@ -98,21 +98,21 @@ do
 		self:EnableResize(true)
 		self:Show()
 	end
-	
+
 	local function OnRelease(self)
 		self.status = nil
 		for k in pairs(self.localstatus) do
 			self.localstatus[k] = nil
 		end
 	end
-	
+
 	-- called to set an external table to store status in
 	local function SetStatusTable(self, status)
 		assert(type(status) == "table")
 		self.status = status
 		self:ApplyStatus()
 	end
-	
+
 	local function ApplyStatus(self)
 		local status = self.status or self.localstatus
 		local frame = self.frame
@@ -125,7 +125,7 @@ do
 			frame:SetPoint("CENTER",UIParent,"CENTER")
 		end
 	end
-	
+
 	local function OnWidthSet(self, width)
 		local content = self.content
 		local contentwidth = width - 34
@@ -135,8 +135,8 @@ do
 		content:SetWidth(contentwidth)
 		content.width = contentwidth
 	end
-	
-	
+
+
 	local function OnHeightSet(self, height)
 		local content = self.content
 		local contentheight = height - 57
@@ -146,19 +146,19 @@ do
 		content:SetHeight(contentheight)
 		content.height = contentheight
 	end
-	
+
 	local function EnableResize(self, state)
 		local func = state and "Show" or "Hide"
 		self.sizer_se[func](self.sizer_se)
 		self.sizer_s[func](self.sizer_s)
 		self.sizer_e[func](self.sizer_e)
 	end
-	
+
 	local function Constructor()
 		local frame = CreateFrame("Frame",nil,UIParent)
 		local self = {}
 		self.type = "Window"
-		
+
 		self.Hide = Hide
 		self.Show = Show
 		self.SetTitle =  SetTitle
@@ -170,9 +170,9 @@ do
 		self.OnWidthSet = OnWidthSet
 		self.OnHeightSet = OnHeightSet
 		self.EnableResize = EnableResize
-		
+
 		self.localstatus = {}
-		
+
 		self.frame = frame
 		frame.obj = self
 		frame:SetWidth(700)
@@ -183,7 +183,7 @@ do
 		frame:SetResizable(true)
 		frame:SetFrameStrata("FULLSCREEN_DIALOG")
 		frame:SetScript("OnMouseDown", frameOnMouseDown)
-		
+
 		frame:SetScript("OnShow",frameOnShow)
 		frame:SetScript("OnHide",frameOnClose)
 		frame:SetMinResize(240,240)
@@ -193,81 +193,81 @@ do
 		titlebg:SetTexture(251966) -- Interface\\PaperDollInfoFrame\\UI-GearManager-Title-Background
 		titlebg:SetPoint("TOPLEFT", 9, -6)
 		titlebg:SetPoint("BOTTOMRIGHT", frame, "TOPRIGHT", -28, -24)
-		
+
 		local dialogbg = frame:CreateTexture(nil, "BACKGROUND")
 		dialogbg:SetTexture(137056) -- Interface\\Tooltips\\UI-Tooltip-Background
 		dialogbg:SetPoint("TOPLEFT", 8, -24)
 		dialogbg:SetPoint("BOTTOMRIGHT", -6, 8)
 		dialogbg:SetVertexColor(0, 0, 0, .75)
-		
+
 		local topleft = frame:CreateTexture(nil, "BORDER")
 		topleft:SetTexture(251963) -- Interface\\PaperDollInfoFrame\\UI-GearManager-Border
 		topleft:SetWidth(64)
 		topleft:SetHeight(64)
 		topleft:SetPoint("TOPLEFT")
 		topleft:SetTexCoord(0.501953125, 0.625, 0, 1)
-		
+
 		local topright = frame:CreateTexture(nil, "BORDER")
 		topright:SetTexture(251963) -- Interface\\PaperDollInfoFrame\\UI-GearManager-Border
 		topright:SetWidth(64)
 		topright:SetHeight(64)
 		topright:SetPoint("TOPRIGHT")
 		topright:SetTexCoord(0.625, 0.75, 0, 1)
-		
+
 		local top = frame:CreateTexture(nil, "BORDER")
 		top:SetTexture(251963) -- Interface\\PaperDollInfoFrame\\UI-GearManager-Border
 		top:SetHeight(64)
 		top:SetPoint("TOPLEFT", topleft, "TOPRIGHT")
 		top:SetPoint("TOPRIGHT", topright, "TOPLEFT")
 		top:SetTexCoord(0.25, 0.369140625, 0, 1)
-		
+
 		local bottomleft = frame:CreateTexture(nil, "BORDER")
 		bottomleft:SetTexture(251963) -- Interface\\PaperDollInfoFrame\\UI-GearManager-Border
 		bottomleft:SetWidth(64)
 		bottomleft:SetHeight(64)
 		bottomleft:SetPoint("BOTTOMLEFT")
 		bottomleft:SetTexCoord(0.751953125, 0.875, 0, 1)
-		
+
 		local bottomright = frame:CreateTexture(nil, "BORDER")
 		bottomright:SetTexture(251963) -- Interface\\PaperDollInfoFrame\\UI-GearManager-Border
 		bottomright:SetWidth(64)
 		bottomright:SetHeight(64)
 		bottomright:SetPoint("BOTTOMRIGHT")
 		bottomright:SetTexCoord(0.875, 1, 0, 1)
-		
+
 		local bottom = frame:CreateTexture(nil, "BORDER")
 		bottom:SetTexture(251963) -- Interface\\PaperDollInfoFrame\\UI-GearManager-Border
 		bottom:SetHeight(64)
 		bottom:SetPoint("BOTTOMLEFT", bottomleft, "BOTTOMRIGHT")
 		bottom:SetPoint("BOTTOMRIGHT", bottomright, "BOTTOMLEFT")
 		bottom:SetTexCoord(0.376953125, 0.498046875, 0, 1)
-		
+
 		local left = frame:CreateTexture(nil, "BORDER")
 		left:SetTexture(251963) -- Interface\\PaperDollInfoFrame\\UI-GearManager-Border
 		left:SetWidth(64)
 		left:SetPoint("TOPLEFT", topleft, "BOTTOMLEFT")
 		left:SetPoint("BOTTOMLEFT", bottomleft, "TOPLEFT")
 		left:SetTexCoord(0.001953125, 0.125, 0, 1)
-		
+
 		local right = frame:CreateTexture(nil, "BORDER")
 		right:SetTexture(251963) -- Interface\\PaperDollInfoFrame\\UI-GearManager-Border
 		right:SetWidth(64)
 		right:SetPoint("TOPRIGHT", topright, "BOTTOMRIGHT")
 		right:SetPoint("BOTTOMRIGHT", bottomright, "TOPRIGHT")
 		right:SetTexCoord(0.1171875, 0.2421875, 0, 1)
-		
+
 		local close = CreateFrame("Button", nil, frame, "UIPanelCloseButton")
 		close:SetPoint("TOPRIGHT", 2, 1)
 		close:SetScript("OnClick", closeOnClick)
 		self.closebutton = close
 		close.obj = self
-		
+
 		local titletext = frame:CreateFontString(nil, "ARTWORK")
 		titletext:SetFontObject(GameFontNormal)
 		titletext:SetPoint("TOPLEFT", 12, -8)
 		titletext:SetPoint("TOPRIGHT", -32, -8)
 		self.titletext = titletext
-		
+
 		local title = CreateFrame("Button", nil, frame)
 		title:SetPoint("TOPLEFT", titlebg)
 		title:SetPoint("BOTTOMRIGHT", titlebg)
@@ -275,7 +275,7 @@ do
 		title:SetScript("OnMouseDown",titleOnMouseDown)
 		title:SetScript("OnMouseUp", frameOnMouseUp)
 		self.title = title
-		
+
 		local sizer_se = CreateFrame("Frame",nil,frame)
 		sizer_se:SetPoint("BOTTOMRIGHT",frame,"BOTTOMRIGHT",0,0)
 		sizer_se:SetWidth(25)
@@ -311,7 +311,7 @@ do
 		sizer_s:SetScript("OnMouseDown",sizersOnMouseDown)
 		sizer_s:SetScript("OnMouseUp", sizerOnMouseUp)
 		self.sizer_s = sizer_s
-		
+
 		local sizer_e = CreateFrame("Frame",nil,frame)
 		sizer_e:SetPoint("BOTTOMRIGHT",frame,"BOTTOMRIGHT",0,25)
 		sizer_e:SetPoint("TOPRIGHT",frame,"TOPRIGHT",0,0)
@@ -320,17 +320,17 @@ do
 		sizer_e:SetScript("OnMouseDown",sizereOnMouseDown)
 		sizer_e:SetScript("OnMouseUp", sizerOnMouseUp)
 		self.sizer_e = sizer_e
-	
+
 		--Container Support
 		local content = CreateFrame("Frame",nil,frame)
 		self.content = content
 		content.obj = self
 		content:SetPoint("TOPLEFT",frame,"TOPLEFT",12,-32)
 		content:SetPoint("BOTTOMRIGHT",frame,"BOTTOMRIGHT",-12,13)
-		
+
 		AceGUI:RegisterAsContainer(self)
-		return self	
+		return self
 	end
-	
+
 	AceGUI:RegisterWidgetType(Type,Constructor,Version)
 end

--- a/Libs/AceGUI-3.0/widgets/AceGUIwidget-Button.lua
+++ b/Libs/AceGUI-3.0/widgets/AceGUIwidget-Button.lua
@@ -51,7 +51,7 @@ local methods = {
 			self:SetWidth(self.text:GetStringWidth() + 30)
 		end
 	end,
-	
+
 	["SetAutoWidth"] = function(self, autoWidth)
 		self.autoWidth = autoWidth
 		if self.autoWidth then

--- a/Libs/AceGUI-3.0/widgets/AceGUIwidget-CheckBox.lua
+++ b/Libs/AceGUI-3.0/widgets/AceGUIwidget-CheckBox.lua
@@ -221,11 +221,11 @@ local methods = {
 			self:SetHeight(24)
 		end
 	end,
-	
+
 	["SetImage"] = function(self, path, ...)
 		local image = self.image
 		image:SetTexture(path)
-		
+
 		if image:GetTexture() then
 			local n = select("#", ...)
 			if n == 4 or n == 8 then

--- a/Libs/AceGUI-3.0/widgets/AceGUIwidget-ColorPicker.lua
+++ b/Libs/AceGUI-3.0/widgets/AceGUIwidget-ColorPicker.lua
@@ -1,7 +1,7 @@
 --[[-----------------------------------------------------------------------------
 ColorPicker Widget
 -------------------------------------------------------------------------------]]
-local Type, Version = "ColorPicker", 24
+local Type, Version = "ColorPicker", 25
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
 if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
 
@@ -13,7 +13,7 @@ local CreateFrame, UIParent = CreateFrame, UIParent
 
 -- Global vars/functions that we don't upvalue since they might get hooked, or upgraded
 -- List them here for Mikk's FindGlobals script
--- GLOBALS: ShowUIPanel, HideUIPanel, ColorPickerFrame, OpacitySliderFrame
+-- GLOBALS: ColorPickerFrame, OpacitySliderFrame
 
 --[[-----------------------------------------------------------------------------
 Support functions
@@ -47,7 +47,7 @@ local function Control_OnLeave(frame)
 end
 
 local function ColorSwatch_OnClick(frame)
-	HideUIPanel(ColorPickerFrame)
+	ColorPickerFrame:Hide()
 	local self = frame.obj
 	if not self.disabled then
 		ColorPickerFrame:SetFrameStrata("FULLSCREEN_DIALOG")
@@ -77,7 +77,7 @@ local function ColorSwatch_OnClick(frame)
 			ColorCallback(self, r, g, b, a, true)
 		end
 
-		ShowUIPanel(ColorPickerFrame)
+		ColorPickerFrame:Show()
 	end
 	AceGUI:ClearFocus()
 end

--- a/Libs/AceGUI-3.0/widgets/AceGUIwidget-DropDown-Items.lua
+++ b/Libs/AceGUI-3.0/widgets/AceGUIwidget-DropDown-Items.lua
@@ -1,4 +1,4 @@
---[[ $Id: AceGUIWidget-DropDown-Items.lua 1192 2018-07-30 18:03:51Z funkydude $ ]]--
+--[[ $Id: AceGUIWidget-DropDown-Items.lua 1202 2019-05-15 23:11:22Z nevcairiel $ ]]--
 
 local AceGUI = LibStub("AceGUI-3.0")
 
@@ -33,7 +33,7 @@ end
 
 -- ItemBase is the base "class" for all dropdown items.
 -- Each item has to use ItemBase.Create(widgetType) to
--- create an initial 'self' value. 
+-- create an initial 'self' value.
 -- ItemBase will add common functions and ui event handlers.
 -- Be sure to keep basic usage when you override functions.
 
@@ -52,7 +52,7 @@ function ItemBase.Frame_OnEnter(this)
 		self.highlight:Show()
 	end
 	self:Fire("OnEnter")
-	
+
 	if self.specialOnEnter then
 		self.specialOnEnter(self)
 	end
@@ -60,10 +60,10 @@ end
 
 function ItemBase.Frame_OnLeave(this)
 	local self = this.obj
-	
+
 	self.highlight:Hide()
 	self:Fire("OnLeave")
-	
+
 	if self.specialOnLeave then
 		self.specialOnLeave(self)
 	end
@@ -89,7 +89,7 @@ end
 --       Do not call this method directly
 function ItemBase.SetPullout(self, pullout)
 	self.pullout = pullout
-	
+
 	self.frame:SetParent(nil)
 	self.frame:SetParent(pullout.itemFrame)
 	self.parent = pullout.itemFrame
@@ -155,12 +155,12 @@ function ItemBase.Create(type)
 	self.frame = frame
 	frame.obj = self
 	self.type = type
-	
+
 	self.useHighlight = true
-	
+
 	frame:SetHeight(17)
 	frame:SetFrameStrata("FULLSCREEN_DIALOG")
-	
+
 	local text = frame:CreateFontString(nil,"OVERLAY","GameFontNormalSmall")
 	text:SetTextColor(1,1,1)
 	text:SetJustifyH("LEFT")
@@ -178,7 +178,7 @@ function ItemBase.Create(type)
 	highlight:Hide()
 	self.highlight = highlight
 
-	local check = frame:CreateTexture("OVERLAY")	
+	local check = frame:CreateTexture("OVERLAY")
 	check:SetWidth(16)
 	check:SetHeight(16)
 	check:SetPoint("LEFT",frame,"LEFT",3,-1)
@@ -192,26 +192,26 @@ function ItemBase.Create(type)
 	sub:SetPoint("RIGHT",frame,"RIGHT",-3,-1)
 	sub:SetTexture(130940) -- Interface\\ChatFrame\\ChatFrameExpandArrow
 	sub:Hide()
-	self.sub = sub	
-	
+	self.sub = sub
+
 	frame:SetScript("OnEnter", ItemBase.Frame_OnEnter)
 	frame:SetScript("OnLeave", ItemBase.Frame_OnLeave)
-	
+
 	self.OnAcquire = ItemBase.OnAcquire
 	self.OnRelease = ItemBase.OnRelease
-	
+
 	self.SetPullout = ItemBase.SetPullout
 	self.GetText    = ItemBase.GetText
 	self.SetText    = ItemBase.SetText
 	self.SetDisabled = ItemBase.SetDisabled
-	
+
 	self.SetPoint   = ItemBase.SetPoint
 	self.Show       = ItemBase.Show
 	self.Hide       = ItemBase.Hide
-	
+
 	self.SetOnLeave = ItemBase.SetOnLeave
 	self.SetOnEnter = ItemBase.SetOnEnter
-	
+
 	return self
 end
 
@@ -223,20 +223,20 @@ end
 
 --[[
 	Template for items:
-	
+
 -- Item:
 --
 do
 	local widgetType = "Dropdown-Item-"
 	local widgetVersion = 1
-	
+
 	local function Constructor()
 		local self = ItemBase.Create(widgetType)
-		
+
 		AceGUI:RegisterAsWidget(self)
 		return self
 	end
-	
+
 	AceGUI:RegisterWidgetType(widgetType, Constructor, widgetVersion + ItemBase.version)
 end
 --]]
@@ -247,25 +247,25 @@ end
 do
 	local widgetType = "Dropdown-Item-Header"
 	local widgetVersion = 1
-	
+
 	local function OnEnter(this)
 		local self = this.obj
 		self:Fire("OnEnter")
-		
+
 		if self.specialOnEnter then
 			self.specialOnEnter(self)
 		end
 	end
-	
+
 	local function OnLeave(this)
 		local self = this.obj
 		self:Fire("OnLeave")
-		
+
 		if self.specialOnLeave then
 			self.specialOnLeave(self)
 		end
 	end
-	
+
 	-- exported, override
 	local function SetDisabled(self, disabled)
 		ItemBase.SetDisabled(self, disabled)
@@ -273,21 +273,21 @@ do
 			self.text:SetTextColor(1, 1, 0)
 		end
 	end
-	
+
 	local function Constructor()
 		local self = ItemBase.Create(widgetType)
-		
+
 		self.SetDisabled = SetDisabled
-		
+
 		self.frame:SetScript("OnEnter", OnEnter)
 		self.frame:SetScript("OnLeave", OnLeave)
-		
+
 		self.text:SetTextColor(1, 1, 0)
-		
+
 		AceGUI:RegisterAsWidget(self)
 		return self
 	end
-	
+
 	AceGUI:RegisterWidgetType(widgetType, Constructor, widgetVersion + ItemBase.version)
 end
 
@@ -296,7 +296,7 @@ end
 do
 	local widgetType = "Dropdown-Item-Execute"
 	local widgetVersion = 1
-	
+
 	local function Frame_OnClick(this, button)
 		local self = this.obj
 		if self.disabled then return end
@@ -305,16 +305,16 @@ do
 			self.pullout:Close()
 		end
 	end
-	
+
 	local function Constructor()
 		local self = ItemBase.Create(widgetType)
-		
+
 		self.frame:SetScript("OnClick", Frame_OnClick)
-		
+
 		AceGUI:RegisterAsWidget(self)
 		return self
 	end
-	
+
 	AceGUI:RegisterWidgetType(widgetType, Constructor, widgetVersion + ItemBase.version)
 end
 
@@ -324,7 +324,7 @@ end
 do
 	local widgetType = "Dropdown-Item-Toggle"
 	local widgetVersion = 4
-	
+
 	local function UpdateToggle(self)
 		if self.value then
 			self.check:Show()
@@ -332,12 +332,12 @@ do
 			self.check:Hide()
 		end
 	end
-	
+
 	local function OnRelease(self)
 		ItemBase.OnRelease(self)
 		self:SetValue(nil)
 	end
-	
+
 	local function Frame_OnClick(this, button)
 		local self = this.obj
 		if self.disabled then return end
@@ -350,31 +350,31 @@ do
 		UpdateToggle(self)
 		self:Fire("OnValueChanged", self.value)
 	end
-	
+
 	-- exported
 	local function SetValue(self, value)
 		self.value = value
 		UpdateToggle(self)
 	end
-	
+
 	-- exported
 	local function GetValue(self)
 		return self.value
 	end
-	
+
 	local function Constructor()
 		local self = ItemBase.Create(widgetType)
-		
+
 		self.frame:SetScript("OnClick", Frame_OnClick)
-		
+
 		self.SetValue = SetValue
 		self.GetValue = GetValue
 		self.OnRelease = OnRelease
-		
+
 		AceGUI:RegisterAsWidget(self)
 		return self
 	end
-	
+
 	AceGUI:RegisterWidgetType(widgetType, Constructor, widgetVersion + ItemBase.version)
 end
 
@@ -384,55 +384,55 @@ end
 do
 	local widgetType = "Dropdown-Item-Menu"
 	local widgetVersion = 2
-	
+
 	local function OnEnter(this)
 		local self = this.obj
 		self:Fire("OnEnter")
-		
+
 		if self.specialOnEnter then
 			self.specialOnEnter(self)
 		end
-		
+
 		self.highlight:Show()
-		
+
 		if not self.disabled and self.submenu then
 			self.submenu:Open("TOPLEFT", self.frame, "TOPRIGHT", self.pullout:GetRightBorderWidth(), 0, self.frame:GetFrameLevel() + 100)
 		end
 	end
-	
+
 	local function OnHide(this)
 		local self = this.obj
 		if self.submenu then
 			self.submenu:Close()
 		end
 	end
-	
+
 	-- exported
 	local function SetMenu(self, menu)
 		assert(menu.type == "Dropdown-Pullout")
 		self.submenu = menu
 	end
-		
+
 	-- exported
 	local function CloseMenu(self)
 		self.submenu:Close()
 	end
-		
+
 	local function Constructor()
 		local self = ItemBase.Create(widgetType)
-		
+
 		self.sub:Show()
-		
+
 		self.frame:SetScript("OnEnter", OnEnter)
 		self.frame:SetScript("OnHide", OnHide)
-		
+
 		self.SetMenu   = SetMenu
 		self.CloseMenu = CloseMenu
-		
+
 		AceGUI:RegisterAsWidget(self)
 		return self
 	end
-	
+
 	AceGUI:RegisterWidgetType(widgetType, Constructor, widgetVersion + ItemBase.version)
 end
 
@@ -441,31 +441,31 @@ end
 do
 	local widgetType = "Dropdown-Item-Separator"
 	local widgetVersion = 2
-	
+
 	-- exported, override
 	local function SetDisabled(self, disabled)
 		ItemBase.SetDisabled(self, disabled)
 		self.useHighlight = false
 	end
-		
+
 	local function Constructor()
 		local self = ItemBase.Create(widgetType)
-		
+
 		self.SetDisabled = SetDisabled
-		
+
 		local line = self.frame:CreateTexture(nil, "OVERLAY")
 		line:SetHeight(1)
 		line:SetColorTexture(.5, .5, .5)
 		line:SetPoint("LEFT", self.frame, "LEFT", 10, 0)
 		line:SetPoint("RIGHT", self.frame, "RIGHT", -10, 0)
-		
+
 		self.text:Hide()
-		
+
 		self.useHighlight = false
-		
+
 		AceGUI:RegisterAsWidget(self)
 		return self
 	end
-	
+
 	AceGUI:RegisterWidgetType(widgetType, Constructor, widgetVersion + ItemBase.version)
 end

--- a/Libs/AceGUI-3.0/widgets/AceGUIwidget-DropDown.lua
+++ b/Libs/AceGUI-3.0/widgets/AceGUIwidget-DropDown.lua
@@ -1,9 +1,9 @@
---[[ $Id: AceGUIWidget-DropDown.lua 1167 2017-08-29 22:08:48Z funkydude $ ]]--
+--[[ $Id: AceGUIWidget-DropDown.lua 1239 2020-09-20 10:22:02Z nevcairiel $ ]]--
 local AceGUI = LibStub("AceGUI-3.0")
 
 -- Lua APIs
 local min, max, floor = math.min, math.max, math.floor
-local select, pairs, ipairs, type = select, pairs, ipairs, type
+local select, pairs, ipairs, type, tostring = select, pairs, ipairs, type, tostring
 local tsort = table.sort
 
 -- WoW APIs
@@ -39,10 +39,10 @@ end
 
 do
 	local widgetType = "Dropdown-Pullout"
-	local widgetVersion = 3
-	
+	local widgetVersion = 5
+
 	--[[ Static data ]]--
-	
+
 	local backdrop = {
 		bgFile = "Interface\\ChatFrame\\ChatFrameBackground",
 		edgeFile = "Interface\\DialogFrame\\UI-DialogBox-Border",
@@ -60,9 +60,9 @@ do
 
 	local defaultWidth = 200
 	local defaultMaxHeight = 600
-	
+
 	--[[ UI Event Handlers ]]--
-	
+
 	-- HACK: This should be no part of the pullout, but there
 	--       is no other 'clean' way to response to any item-OnEnter
 	--       Used to close Submenus when an other item is entered
@@ -74,22 +74,22 @@ do
 			end
 		end
 	end
-	
+
 	-- See the note in Constructor() for each scroll related function
 	local function OnMouseWheel(this, value)
 		this.obj:MoveScroll(value)
 	end
-	
+
 	local function OnScrollValueChanged(this, value)
 		this.obj:SetScroll(value)
 	end
-	
+
 	local function OnSizeChanged(this)
 		this.obj:FixScroll()
 	end
-	
+
 	--[[ Exported methods ]]--
-	
+
 	-- exported
 	local function SetScroll(self, value)
 		local status = self.scrollStatus
@@ -106,9 +106,9 @@ do
 		child:SetPoint("TOPLEFT", frame, "TOPLEFT", 0, offset)
 		child:SetPoint("TOPRIGHT", frame, "TOPRIGHT", self.slider:IsShown() and -12 or 0, offset)
 		status.offset = offset
-		status.scrollvalue = value		
+		status.scrollvalue = value
 	end
-	
+
 	-- exported
 	local function MoveScroll(self, value)
 		local status = self.scrollStatus
@@ -127,7 +127,7 @@ do
 			self.slider:SetValue(min(max(status.scrollvalue + delta*(1000/(diff/45)),0), 1000))
 		end
 	end
-	
+
 	-- exported
 	local function FixScroll(self)
 		local status = self.scrollStatus
@@ -140,7 +140,7 @@ do
 			child:SetPoint("TOPRIGHT", frame, "TOPRIGHT", 0, offset)
 			self.slider:SetValue(0)
 		else
-			self.slider:Show()			
+			self.slider:Show()
 			local value = (offset / (viewheight - height) * 1000)
 			if value > 1000 then value = 1000 end
 			self.slider:SetValue(value)
@@ -153,68 +153,63 @@ do
 			end
 		end
 	end
-	
+
 	-- exported, AceGUI callback
 	local function OnAcquire(self)
 		self.frame:SetParent(UIParent)
 		--self.itemFrame:SetToplevel(true)
 	end
-	
+
 	-- exported, AceGUI callback
 	local function OnRelease(self)
 		self:Clear()
 		self.frame:ClearAllPoints()
 		self.frame:Hide()
 	end
-	
+
 	-- exported
 	local function AddItem(self, item)
 		self.items[#self.items + 1] = item
-		
+
 		local h = #self.items * 16
 		self.itemFrame:SetHeight(h)
 		self.frame:SetHeight(min(h + 34, self.maxHeight)) -- +34: 20 for scrollFrame placement (10 offset) and +14 for item placement
-		
+
 		item.frame:SetPoint("LEFT", self.itemFrame, "LEFT")
 		item.frame:SetPoint("RIGHT", self.itemFrame, "RIGHT")
-		
+
 		item:SetPullout(self)
 		item:SetOnEnter(OnEnter)
 	end
-		
+
 	-- exported
-	local function Open(self, point, relFrame, relPoint, x, y)		
+	local function Open(self, point, relFrame, relPoint, x, y)
 		local items = self.items
 		local frame = self.frame
 		local itemFrame = self.itemFrame
-		
+
 		frame:SetPoint(point, relFrame, relPoint, x, y)
 
-				
+
 		local height = 8
 		for i, item in pairs(items) do
-			if i == 1 then
-				item:SetPoint("TOP", itemFrame, "TOP", 0, -2)
-			else
-				item:SetPoint("TOP", items[i-1].frame, "BOTTOM", 0, 1)
-			end
-			
+			item:SetPoint("TOP", itemFrame, "TOP", 0, -2 + (i - 1) * -16)
 			item:Show()
-			
+
 			height = height + 16
 		end
 		itemFrame:SetHeight(height)
 		fixstrata("TOOLTIP", frame, frame:GetChildren())
 		frame:Show()
 		self:Fire("OnOpen")
-	end	
-	
+	end
+
 	-- exported
 	local function Close(self)
 		self.frame:Hide()
 		self:Fire("OnClose")
-	end	
-	
+	end
+
 	-- exported
 	local function Clear(self)
 		local items = self.items
@@ -222,18 +217,18 @@ do
 			AceGUI:Release(item)
 			items[i] = nil
 		end
-	end	
-	
+	end
+
 	-- exported
 	local function IterateItems(self)
 		return ipairs(self.items)
 	end
-	
+
 	-- exported
 	local function SetHideOnLeave(self, val)
 		self.hideOnLeave = val
 	end
-	
+
 	-- exported
 	local function SetMaxHeight(self, height)
 		self.maxHeight = height or defaultMaxHeight
@@ -243,28 +238,28 @@ do
 			self.frame:SetHeight(self.itemFrame:GetHeight() + 34) -- see :AddItem
 		end
 	end
-		
+
 	-- exported
 	local function GetRightBorderWidth(self)
 		return 6 + (self.slider:IsShown() and 12 or 0)
 	end
-	
+
 	-- exported
 	local function GetLeftBorderWidth(self)
 		return 6
 	end
-	
+
 	--[[ Constructor ]]--
-	
+
 	local function Constructor()
 		local count = AceGUI:GetNextWidgetNum(widgetType)
-		local frame = CreateFrame("Frame", "AceGUI30Pullout"..count, UIParent)
+		local frame = CreateFrame("Frame", "AceGUI30Pullout"..count, UIParent, BackdropTemplateMixin and "BackdropTemplate" or nil)
 		local self = {}
 		self.count = count
 		self.type = widgetType
 		self.frame = frame
 		frame.obj = self
-		
+
 		self.OnAcquire = OnAcquire
 		self.OnRelease = OnRelease
 
@@ -278,38 +273,38 @@ do
 		self.SetScroll  = SetScroll
 		self.MoveScroll = MoveScroll
 		self.FixScroll  = FixScroll
-		
+
 		self.SetMaxHeight = SetMaxHeight
 		self.GetRightBorderWidth = GetRightBorderWidth
 		self.GetLeftBorderWidth = GetLeftBorderWidth
-		
+
 		self.items = {}
-		
+
 		self.scrollStatus = {
 			scrollvalue = 0,
 		}
-		
+
 		self.maxHeight = defaultMaxHeight
-			
+
 		frame:SetBackdrop(backdrop)
 		frame:SetBackdropColor(0, 0, 0)
 		frame:SetFrameStrata("FULLSCREEN_DIALOG")
 		frame:SetClampedToScreen(true)
 		frame:SetWidth(defaultWidth)
-		frame:SetHeight(self.maxHeight)	
+		frame:SetHeight(self.maxHeight)
 		--frame:SetToplevel(true)
-	
+
 		-- NOTE: The whole scroll frame code is copied from the AceGUI-3.0 widget ScrollFrame
 		local scrollFrame = CreateFrame("ScrollFrame", nil, frame)
 		local itemFrame = CreateFrame("Frame", nil, scrollFrame)
-		
+
 		self.scrollFrame = scrollFrame
 		self.itemFrame = itemFrame
-		
+
 		scrollFrame.obj = self
 		itemFrame.obj = self
-		
-		local slider = CreateFrame("Slider", "AceGUI30PulloutScrollbar"..count, scrollFrame)
+
+		local slider = CreateFrame("Slider", "AceGUI30PulloutScrollbar"..count, scrollFrame, BackdropTemplateMixin and "BackdropTemplate" or nil)
 		slider:SetOrientation("VERTICAL")
 		slider:SetHitRectInsets(0, 0, -10, 0)
 		slider:SetBackdrop(sliderBackdrop)
@@ -318,7 +313,7 @@ do
 		slider:SetFrameStrata("FULLSCREEN_DIALOG")
 		self.slider = slider
 		slider.obj = self
-					
+
 		scrollFrame:SetScrollChild(itemFrame)
 		scrollFrame:SetPoint("TOPLEFT", frame, "TOPLEFT", 6, -12)
 		scrollFrame:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -6, 12)
@@ -327,46 +322,46 @@ do
 		scrollFrame:SetScript("OnSizeChanged", OnSizeChanged)
 		scrollFrame:SetToplevel(true)
 		scrollFrame:SetFrameStrata("FULLSCREEN_DIALOG")
-		
+
 		itemFrame:SetPoint("TOPLEFT", scrollFrame, "TOPLEFT", 0, 0)
 		itemFrame:SetPoint("TOPRIGHT", scrollFrame, "TOPRIGHT", -12, 0)
 		itemFrame:SetHeight(400)
 		itemFrame:SetToplevel(true)
 		itemFrame:SetFrameStrata("FULLSCREEN_DIALOG")
-		
+
 		slider:SetPoint("TOPLEFT", scrollFrame, "TOPRIGHT", -16, 0)
 		slider:SetPoint("BOTTOMLEFT", scrollFrame, "BOTTOMRIGHT", -16, 0)
 		slider:SetScript("OnValueChanged", OnScrollValueChanged)
 		slider:SetMinMaxValues(0, 1000)
 		slider:SetValueStep(1)
 		slider:SetValue(0)
-		
+
 		scrollFrame:Show()
 		itemFrame:Show()
 		slider:Hide()
-						
+
 		self:FixScroll()
-		
+
 		AceGUI:RegisterAsWidget(self)
 		return self
 	end
-	
+
 	AceGUI:RegisterWidgetType(widgetType, Constructor, widgetVersion)
 end
 
 do
 	local widgetType = "Dropdown"
-	local widgetVersion = 31
-	
+	local widgetVersion = 35
+
 	--[[ Static data ]]--
-	
+
 	--[[ UI event handler ]]--
-	
+
 	local function Control_OnEnter(this)
 		this.obj.button:LockHighlight()
 		this.obj:Fire("OnEnter")
 	end
-	
+
 	local function Control_OnLeave(this)
 		this.obj.button:UnlockHighlight()
 		this.obj:Fire("OnLeave")
@@ -378,7 +373,7 @@ do
 			self.pullout:Close()
 		end
 	end
-	
+
 	local function Dropdown_TogglePullout(this)
 		local self = this.obj
 		PlaySound(856) -- SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON
@@ -393,17 +388,17 @@ do
 			AceGUI:SetFocus(self)
 		end
 	end
-	
+
 	local function OnPulloutOpen(this)
 		local self = this.userdata.obj
 		local value = self.value
-		
+
 		if not self.multiselect then
 			for i, item in this:IterateItems() do
 				item:SetValue(item.userdata.value == value)
 			end
 		end
-		
+
 		self.open = true
 		self:Fire("OnOpened")
 	end
@@ -413,7 +408,7 @@ do
 		self.open = nil
 		self:Fire("OnClosed")
 	end
-	
+
 	local function ShowMultiText(self)
 		local text
 		for i, widget in self.pullout:IterateItems() do
@@ -429,10 +424,10 @@ do
 		end
 		self:SetText(text)
 	end
-	
+
 	local function OnItemValueChanged(this, event, checked)
 		local self = this.userdata.obj
-		
+
 		if self.multiselect then
 			self:Fire("OnValueChanged", this.userdata.value, checked)
 			ShowMultiText(self)
@@ -443,14 +438,14 @@ do
 			else
 				this:SetValue(true)
 			end
-			if self.open then	
+			if self.open then
 				self.pullout:Close()
 			end
 		end
 	end
-	
+
 	--[[ Exported methods ]]--
-	
+
 	-- exported, AceGUI callback
 	local function OnAcquire(self)
 		local pullout = AceGUI:Create("Dropdown-Pullout")
@@ -460,13 +455,14 @@ do
 		pullout:SetCallback("OnOpen", OnPulloutOpen)
 		self.pullout.frame:SetFrameLevel(self.frame:GetFrameLevel() + 1)
 		fixlevels(self.pullout.frame, self.pullout.frame:GetChildren())
-		
+
 		self:SetHeight(44)
 		self:SetWidth(200)
 		self:SetLabel()
 		self:SetPulloutWidth(nil)
+		self.list = {}
 	end
-	
+
 	-- exported, AceGUI callback
 	local function OnRelease(self)
 		if self.open then
@@ -474,20 +470,20 @@ do
 		end
 		AceGUI:Release(self.pullout)
 		self.pullout = nil
-		
+
 		self:SetText("")
 		self:SetDisabled(false)
 		self:SetMultiselect(false)
-		
+
 		self.value = nil
 		self.list = nil
 		self.open = nil
 		self.hasClose = nil
-		
+
 		self.frame:ClearAllPoints()
 		self.frame:Hide()
 	end
-	
+
 	-- exported
 	local function SetDisabled(self, disabled)
 		self.disabled = disabled
@@ -503,19 +499,19 @@ do
 			self.text:SetTextColor(1,1,1)
 		end
 	end
-	
+
 	-- exported
 	local function ClearFocus(self)
 		if self.open then
 			self.pullout:Close()
 		end
 	end
-	
+
 	-- exported
 	local function SetText(self, text)
 		self.text:SetText(text or "")
 	end
-	
+
 	-- exported
 	local function SetLabel(self, text)
 		if text and text ~= "" then
@@ -532,20 +528,18 @@ do
 			self.alignoffset = 12
 		end
 	end
-	
+
 	-- exported
 	local function SetValue(self, value)
-		if self.list then
-			self:SetText(self.list[value] or "")
-		end
+		self:SetText(self.list[value] or "")
 		self.value = value
 	end
-	
+
 	-- exported
 	local function GetValue(self)
 		return self.value
 	end
-	
+
 	-- exported
 	local function SetItemValue(self, item, value)
 		if not self.multiselect then return end
@@ -558,7 +552,7 @@ do
 		end
 		ShowMultiText(self)
 	end
-	
+
 	-- exported
 	local function SetItemDisabled(self, item, disabled)
 		for i, widget in self.pullout:IterateItems() do
@@ -567,7 +561,7 @@ do
 			end
 		end
 	end
-	
+
 	local function AddListItem(self, value, text, itemType)
 		if not itemType then itemType = "Dropdown-Item-Toggle" end
 		local exists = AceGUI:GetWidgetVersion(itemType)
@@ -580,7 +574,7 @@ do
 		item:SetCallback("OnValueChanged", OnItemValueChanged)
 		self.pullout:AddItem(item)
 	end
-	
+
 	local function AddCloseButton(self)
 		if not self.hasClose then
 			local close = AceGUI:Create("Dropdown-Item-Execute")
@@ -589,21 +583,29 @@ do
 			self.hasClose = true
 		end
 	end
-	
+
 	-- exported
 	local sortlist = {}
+	local function sortTbl(x,y)
+		local num1, num2 = tonumber(x), tonumber(y)
+		if num1 and num2 then -- numeric comparison, either two numbers or numeric strings
+			return num1 < num2
+		else -- compare everything else tostring'ed
+			return tostring(x) < tostring(y)
+		end
+	end
 	local function SetList(self, list, order, itemType)
-		self.list = list
+		self.list = list or {}
 		self.pullout:Clear()
 		self.hasClose = nil
 		if not list then return end
-		
+
 		if type(order) ~= "table" then
 			for v in pairs(list) do
 				sortlist[#sortlist + 1] = v
 			end
-			tsort(sortlist)
-			
+			tsort(sortlist, sortTbl)
+
 			for i, key in ipairs(sortlist) do
 				AddListItem(self, key, list[key], itemType)
 				sortlist[i] = nil
@@ -618,15 +620,13 @@ do
 			AddCloseButton(self)
 		end
 	end
-	
+
 	-- exported
 	local function AddItem(self, value, text, itemType)
-		if self.list then
-			self.list[value] = text
-			AddListItem(self, value, text, itemType)
-		end
+		self.list[value] = text
+		AddListItem(self, value, text, itemType)
 	end
-	
+
 	-- exported
 	local function SetMultiselect(self, multi)
 		self.multiselect = multi
@@ -635,23 +635,23 @@ do
 			AddCloseButton(self)
 		end
 	end
-	
+
 	-- exported
 	local function GetMultiselect(self)
 		return self.multiselect
 	end
-	
+
 	local function SetPulloutWidth(self, width)
 		self.pulloutWidth = width
 	end
-	
+
 	--[[ Constructor ]]--
-	
+
 	local function Constructor()
 		local count = AceGUI:GetNextWidgetNum(widgetType)
 		local frame = CreateFrame("Frame", nil, UIParent)
 		local dropdown = CreateFrame("Frame", "AceGUI30DropDown"..count, frame, "UIDropDownMenuTemplate")
-		
+
 		local self = {}
 		self.type = widgetType
 		self.frame = frame
@@ -659,10 +659,10 @@ do
 		self.count = count
 		frame.obj = self
 		dropdown.obj = self
-		
+
 		self.OnRelease   = OnRelease
 		self.OnAcquire   = OnAcquire
-		
+
 		self.ClearFocus  = ClearFocus
 
 		self.SetText     = SetText
@@ -677,9 +677,9 @@ do
 		self.SetItemValue = SetItemValue
 		self.SetItemDisabled = SetItemDisabled
 		self.SetPulloutWidth = SetPulloutWidth
-		
+
 		self.alignoffset = 26
-		
+
 		frame:SetScript("OnHide",Dropdown_OnHide)
 
 		dropdown:ClearAllPoints()
@@ -690,10 +690,10 @@ do
 		local left = _G[dropdown:GetName() .. "Left"]
 		local middle = _G[dropdown:GetName() .. "Middle"]
 		local right = _G[dropdown:GetName() .. "Right"]
-		
+
 		middle:ClearAllPoints()
 		right:ClearAllPoints()
-		
+
 		middle:SetPoint("LEFT", left, "RIGHT", 0, 0)
 		middle:SetPoint("RIGHT", right, "LEFT", 0, 0)
 		right:SetPoint("TOPRIGHT", dropdown, "TOPRIGHT", 0, 17)
@@ -704,7 +704,7 @@ do
 		button:SetScript("OnEnter",Control_OnEnter)
 		button:SetScript("OnLeave",Control_OnLeave)
 		button:SetScript("OnClick",Dropdown_TogglePullout)
-		
+
 		local button_cover = CreateFrame("BUTTON",nil,self.frame)
 		self.button_cover = button_cover
 		button_cover.obj = self
@@ -713,14 +713,14 @@ do
 		button_cover:SetScript("OnEnter",Control_OnEnter)
 		button_cover:SetScript("OnLeave",Control_OnLeave)
 		button_cover:SetScript("OnClick",Dropdown_TogglePullout)
-		
+
 		local text = _G[dropdown:GetName() .. "Text"]
 		self.text = text
 		text.obj = self
 		text:ClearAllPoints()
 		text:SetPoint("RIGHT", right, "RIGHT" ,-43, 2)
 		text:SetPoint("LEFT", left, "LEFT", 25, 2)
-		
+
 		local label = frame:CreateFontString(nil,"OVERLAY","GameFontNormalSmall")
 		label:SetPoint("TOPLEFT",frame,"TOPLEFT",0,0)
 		label:SetPoint("TOPRIGHT",frame,"TOPRIGHT",0,0)
@@ -732,6 +732,6 @@ do
 		AceGUI:RegisterAsWidget(self)
 		return self
 	end
-	
+
 	AceGUI:RegisterWidgetType(widgetType, Constructor, widgetVersion)
-end	
+end

--- a/Libs/AceGUI-3.0/widgets/AceGUIwidget-Icon.lua
+++ b/Libs/AceGUI-3.0/widgets/AceGUIwidget-Icon.lua
@@ -56,7 +56,7 @@ local methods = {
 	["SetImage"] = function(self, path, ...)
 		local image = self.image
 		image:SetTexture(path)
-		
+
 		if image:GetTexture() then
 			local n = select("#", ...)
 			if n == 4 or n == 8 then

--- a/Libs/AceGUI-3.0/widgets/AceGUIwidget-Keybinding.lua
+++ b/Libs/AceGUI-3.0/widgets/AceGUIwidget-Keybinding.lua
@@ -2,7 +2,7 @@
 Keybinding Widget
 Set Keybindings in the Config UI.
 -------------------------------------------------------------------------------]]
-local Type, Version = "Keybinding", 25
+local Type, Version = "Keybinding", 26
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
 if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
 
@@ -214,7 +214,7 @@ local function Constructor()
 	label:SetJustifyH("CENTER")
 	label:SetHeight(18)
 
-	local msgframe = CreateFrame("Frame", nil, UIParent)
+	local msgframe = CreateFrame("Frame", nil, UIParent, BackdropTemplateMixin and "BackdropTemplate" or nil)
 	msgframe:SetHeight(30)
 	msgframe:SetBackdrop(ControlBackdrop)
 	msgframe:SetBackdropColor(0,0,0)

--- a/Libs/AceGUI-3.0/widgets/AceGUIwidget-Label.lua
+++ b/Libs/AceGUI-3.0/widgets/AceGUIwidget-Label.lua
@@ -2,7 +2,7 @@
 Label Widget
 Displays text and optionally an icon.
 -------------------------------------------------------------------------------]]
-local Type, Version = "Label", 26
+local Type, Version = "Label", 27
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
 if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
 
@@ -57,12 +57,12 @@ local function UpdateImageAnchor(self)
 		label:SetWidth(width)
 		height = label:GetStringHeight()
 	end
-	
+
 	-- avoid zero-height labels, since they can used as spacers
 	if not height or height == 0 then
 		height = 1
 	end
-	
+
 	self.resizing = true
 	frame:SetHeight(height)
 	frame.height = height
@@ -113,7 +113,7 @@ local methods = {
 	["SetImage"] = function(self, path, ...)
 		local image = self.image
 		image:SetTexture(path)
-		
+
 		if image:GetTexture() then
 			self.imageshown = true
 			local n = select("#", ...)
@@ -130,6 +130,7 @@ local methods = {
 
 	["SetFont"] = function(self, font, height, flags)
 		self.label:SetFont(font, height, flags)
+		UpdateImageAnchor(self)
 	end,
 
 	["SetFontObject"] = function(self, font)

--- a/Libs/AceGUI-3.0/widgets/AceGUIwidget-MultiLineEditBox.lua
+++ b/Libs/AceGUI-3.0/widgets/AceGUIwidget-MultiLineEditBox.lua
@@ -1,4 +1,4 @@
-local Type, Version = "MultiLineEditBox", 28
+local Type, Version = "MultiLineEditBox", 29
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
 if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
 
@@ -233,7 +233,7 @@ local methods = {
 		end
 		Layout(self)
 	end,
-	
+
 	["ClearFocus"] = function(self)
 		self.editBox:ClearFocus()
 		self.frame:SetScript("OnShow", nil)
@@ -253,12 +253,12 @@ local methods = {
 	["GetCursorPosition"] = function(self)
 		return self.editBox:GetCursorPosition()
 	end,
-	
+
 	["SetCursorPosition"] = function(self, ...)
 		return self.editBox:SetCursorPosition(...)
 	end,
-	
-	
+
+
 }
 
 --[[-----------------------------------------------------------------------------
@@ -273,7 +273,7 @@ local backdrop = {
 local function Constructor()
 	local frame = CreateFrame("Frame", nil, UIParent)
 	frame:Hide()
-	
+
 	local widgetNum = AceGUI:GetNextWidgetNum(Type)
 
 	local label = frame:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
@@ -290,14 +290,14 @@ local function Constructor()
 	button:SetText(ACCEPT)
 	button:SetScript("OnClick", OnClick)
 	button:Disable()
-	
+
 	local text = button:GetFontString()
 	text:ClearAllPoints()
 	text:SetPoint("TOPLEFT", button, "TOPLEFT", 5, -5)
 	text:SetPoint("BOTTOMRIGHT", button, "BOTTOMRIGHT", -5, 1)
 	text:SetJustifyV("MIDDLE")
 
-	local scrollBG = CreateFrame("Frame", nil, frame)
+	local scrollBG = CreateFrame("Frame", nil, frame, BackdropTemplateMixin and "BackdropTemplate" or nil)
 	scrollBG:SetBackdrop(backdrop)
 	scrollBG:SetBackdropColor(0, 0, 0)
 	scrollBG:SetBackdropBorderColor(0.4, 0.4, 0.4)
@@ -339,7 +339,7 @@ local function Constructor()
 	editBox:SetScript("OnTextChanged", OnTextChanged)
 	editBox:SetScript("OnTextSet", OnTextSet)
 	editBox:SetScript("OnEditFocusGained", OnEditFocusGained)
-	
+
 
 	scrollFrame:SetScrollChild(editBox)
 

--- a/Libs/AceGUI-3.0/widgets/AceGUIwidget-Slider.lua
+++ b/Libs/AceGUI-3.0/widgets/AceGUIwidget-Slider.lua
@@ -2,7 +2,7 @@
 Slider Widget
 Graphical Slider, like, for Range values.
 -------------------------------------------------------------------------------]]
-local Type, Version = "Slider", 22
+local Type, Version = "Slider", 23
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
 if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
 
@@ -105,7 +105,7 @@ local function EditBox_OnEnterPressed(frame)
 	else
 		value = tonumber(value)
 	end
-	
+
 	if value then
 		PlaySound(856) -- SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON
 		self.slider:SetValue(value)
@@ -225,7 +225,7 @@ local function Constructor()
 	label:SetJustifyH("CENTER")
 	label:SetHeight(15)
 
-	local slider = CreateFrame("Slider", nil, frame)
+	local slider = CreateFrame("Slider", nil, frame, BackdropTemplateMixin and "BackdropTemplate" or nil)
 	slider:SetOrientation("HORIZONTAL")
 	slider:SetHeight(15)
 	slider:SetHitRectInsets(0, 0, -10, 0)
@@ -247,7 +247,7 @@ local function Constructor()
 	local hightext = slider:CreateFontString(nil, "ARTWORK", "GameFontHighlightSmall")
 	hightext:SetPoint("TOPRIGHT", slider, "BOTTOMRIGHT", -2, 3)
 
-	local editbox = CreateFrame("EditBox", nil, frame)
+	local editbox = CreateFrame("EditBox", nil, frame, BackdropTemplateMixin and "BackdropTemplate" or nil)
 	editbox:SetAutoFocus(false)
 	editbox:SetFontObject(GameFontHighlightSmall)
 	editbox:SetPoint("TOP", slider, "BOTTOM")

--- a/Libs/AceHook-3.0/AceHook-3.0.lua
+++ b/Libs/AceHook-3.0/AceHook-3.0.lua
@@ -2,15 +2,15 @@
 -- Using AceHook-3.0 is recommended when you need to unhook your hooks again, so the hook chain isn't broken
 -- when you manually restore the original function.
 --
--- **AceHook-3.0** can be embeded into your addon, either explicitly by calling AceHook:Embed(MyAddon) or by 
+-- **AceHook-3.0** can be embeded into your addon, either explicitly by calling AceHook:Embed(MyAddon) or by
 -- specifying it as an embeded library in your AceAddon. All functions will be available on your addon object
 -- and can be accessed directly, without having to explicitly call AceHook itself.\\
 -- It is recommended to embed AceHook, otherwise you'll have to specify a custom `self` on all calls you
 -- make into AceHook.
 -- @class file
 -- @name AceHook-3.0
--- @release $Id: AceHook-3.0.lua 1118 2014-10-12 08:21:54Z nevcairiel $
-local ACEHOOK_MAJOR, ACEHOOK_MINOR = "AceHook-3.0", 8
+-- @release $Id: AceHook-3.0.lua 1243 2020-10-18 00:00:19Z nevcairiel $
+local ACEHOOK_MAJOR, ACEHOOK_MINOR = "AceHook-3.0", 9
 local AceHook, oldminor = LibStub:NewLibrary(ACEHOOK_MAJOR, ACEHOOK_MINOR)
 
 if not AceHook then return end -- No upgrade needed
@@ -117,14 +117,14 @@ function donothing() end
 
 function hook(self, obj, method, handler, script, secure, raw, forceSecure, usage)
 	if not handler then handler = method end
-	
+
 	-- These asserts make sure AceHooks's devs play by the rules.
 	assert(not script or type(script) == "boolean")
 	assert(not secure or type(secure) == "boolean")
 	assert(not raw or type(raw) == "boolean")
 	assert(not forceSecure or type(forceSecure) == "boolean")
 	assert(usage)
-	
+
 	-- Error checking Battery!
 	if obj and type(obj) ~= "table" then
 		error(format("%s: 'object' - nil or table expected got %s", usage, type(obj)), 3)
@@ -146,8 +146,8 @@ function hook(self, obj, method, handler, script, secure, raw, forceSecure, usag
 			error(format("Cannot hook secure script %q; Use SecureHookScript(obj, method, [handler]) instead.", method), 3)
 		end
 	else
-		local issecure 
-		if obj then 
+		local issecure
+		if obj then
 			issecure = onceSecure[obj] and onceSecure[obj][method] or issecurevariable(obj, method)
 		else
 			issecure = onceSecure[method] or issecurevariable(method)
@@ -165,21 +165,21 @@ function hook(self, obj, method, handler, script, secure, raw, forceSecure, usag
 			end
 		end
 	end
-	
+
 	local uid
 	if obj then
 		uid = registry[self][obj] and registry[self][obj][method]
 	else
 		uid = registry[self][method]
 	end
-	
+
 	if uid then
 		if actives[uid] then
 			-- Only two sane choices exist here.  We either a) error 100% of the time or b) always unhook and then hook
 			-- choice b would likely lead to odd debuging conditions or other mysteries so we're going with a.
 			error(format("Attempting to rehook already active hook %s.", method))
 		end
-		
+
 		if handlers[uid] == handler then -- turn on a decative hook, note enclosures break this ability, small memory leak
 			actives[uid] = true
 			return
@@ -197,7 +197,7 @@ function hook(self, obj, method, handler, script, secure, raw, forceSecure, usag
 		handlers[uid], actives[uid], scripts[uid] = nil, nil, nil
 		uid = nil
 	end
-	
+
 	local orig
 	if script then
 		orig = obj:GetScript(method) or donothing
@@ -206,13 +206,13 @@ function hook(self, obj, method, handler, script, secure, raw, forceSecure, usag
 	else
 		orig = _G[method]
 	end
-	
+
 	if not orig then
 		error(format("%s: Attempting to hook a non existing target", usage), 3)
 	end
-	
+
 	uid = createHook(self, handler, orig, secure, not (raw or secure))
-	
+
 	if obj then
 		self.hooks[obj] = self.hooks[obj] or {}
 		registry[self][obj] = registry[self][obj] or {}
@@ -221,7 +221,7 @@ function hook(self, obj, method, handler, script, secure, raw, forceSecure, usag
 		if not secure then
 			self.hooks[obj][method] = orig
 		end
-		
+
 		if script then
 			if not secure then
 				obj:SetScript(method, uid)
@@ -237,7 +237,7 @@ function hook(self, obj, method, handler, script, secure, raw, forceSecure, usag
 		end
 	else
 		registry[self][method] = uid
-		
+
 		if not secure then
 			_G[method] = uid
 			self.hooks[method] = orig
@@ -245,8 +245,8 @@ function hook(self, obj, method, handler, script, secure, raw, forceSecure, usag
 			hooksecurefunc(method, uid)
 		end
 	end
-	
-	actives[uid], handlers[uid], scripts[uid] = true, handler, script and true or nil	
+
+	actives[uid], handlers[uid], scripts[uid] = true, handler, script and true or nil
 end
 
 --- Hook a function or a method on an object.
@@ -262,7 +262,7 @@ end
 -- @usage
 -- -- create an addon with AceHook embeded
 -- MyAddon = LibStub("AceAddon-3.0"):NewAddon("HookDemo", "AceHook-3.0")
--- 
+--
 -- function MyAddon:OnEnable()
 --   -- Hook ActionButton_UpdateHotkeys, overwriting the secure status
 --   self:Hook("ActionButton_UpdateHotkeys", true)
@@ -275,12 +275,12 @@ function AceHook:Hook(object, method, handler, hookSecure)
 	if type(object) == "string" then
 		method, handler, hookSecure, object = object, method, handler, nil
 	end
-	
+
 	if handler == true then
 		handler, hookSecure = nil, true
 	end
 
-	hook(self, object, method, handler, false, false, false, hookSecure or false, "Usage: Hook([object], method, [handler], [hookSecure])")	
+	hook(self, object, method, handler, false, false, false, hookSecure or false, "Usage: Hook([object], method, [handler], [hookSecure])")
 end
 
 --- RawHook a function or a method on an object.
@@ -297,7 +297,7 @@ end
 -- @usage
 -- -- create an addon with AceHook embeded
 -- MyAddon = LibStub("AceAddon-3.0"):NewAddon("HookDemo", "AceHook-3.0")
--- 
+--
 -- function MyAddon:OnEnable()
 --   -- Hook ActionButton_UpdateHotkeys, overwriting the secure status
 --   self:RawHook("ActionButton_UpdateHotkeys", true)
@@ -314,11 +314,11 @@ function AceHook:RawHook(object, method, handler, hookSecure)
 	if type(object) == "string" then
 		method, handler, hookSecure, object = object, method, handler, nil
 	end
-	
+
 	if handler == true then
 		handler, hookSecure = nil, true
 	end
-	
+
 	hook(self, object, method, handler, false, false, true, hookSecure or false,  "Usage: RawHook([object], method, [handler], [hookSecure])")
 end
 
@@ -337,7 +337,7 @@ function AceHook:SecureHook(object, method, handler)
 	if type(object) == "string" then
 		method, handler, object = object, method, nil
 	end
-	
+
 	hook(self, object, method, handler, false, true, false, false,  "Usage: SecureHook([object], method, [handler])")
 end
 
@@ -354,9 +354,9 @@ end
 -- @usage
 -- -- create an addon with AceHook embeded
 -- MyAddon = LibStub("AceAddon-3.0"):NewAddon("HookDemo", "AceHook-3.0")
--- 
+--
 -- function MyAddon:OnEnable()
---   -- Hook the OnShow of FriendsFrame 
+--   -- Hook the OnShow of FriendsFrame
 --   self:HookScript(FriendsFrame, "OnShow", "FriendsFrameOnShow")
 -- end
 --
@@ -380,9 +380,9 @@ end
 -- @usage
 -- -- create an addon with AceHook embeded
 -- MyAddon = LibStub("AceAddon-3.0"):NewAddon("HookDemo", "AceHook-3.0")
--- 
+--
 -- function MyAddon:OnEnable()
---   -- Hook the OnShow of FriendsFrame 
+--   -- Hook the OnShow of FriendsFrame
 --   self:RawHookScript(FriendsFrame, "OnShow", "FriendsFrameOnShow")
 -- end
 --
@@ -420,54 +420,54 @@ function AceHook:Unhook(obj, method)
 	if type(obj) == "string" then
 		method, obj = obj, nil
 	end
-		
+
 	if obj and type(obj) ~= "table" then
 		error(format("%s: 'obj' - expecting nil or table got %s", usage, type(obj)), 2)
 	end
 	if type(method) ~= "string" then
 		error(format("%s: 'method' - expeting string got %s", usage, type(method)), 2)
 	end
-	
+
 	local uid
 	if obj then
 		uid = registry[self][obj] and registry[self][obj][method]
 	else
 		uid = registry[self][method]
 	end
-	
+
 	if not uid or not actives[uid] then
 		-- Declining to error on an unneeded unhook since the end effect is the same and this would just be annoying.
 		return false
 	end
-	
+
 	actives[uid], handlers[uid] = nil, nil
-	
+
 	if obj then
 		registry[self][obj][method] = nil
 		registry[self][obj] = next(registry[self][obj]) and registry[self][obj] or nil
-		
+
 		-- if the hook reference doesnt exist, then its a secure hook, just bail out and dont do any unhooking
 		if not self.hooks[obj] or not self.hooks[obj][method] then return true end
-		
+
 		if scripts[uid] and obj:GetScript(method) == uid then  -- unhooks scripts
-			obj:SetScript(method, self.hooks[obj][method] ~= donothing and self.hooks[obj][method] or nil)	
+			obj:SetScript(method, self.hooks[obj][method] ~= donothing and self.hooks[obj][method] or nil)
 			scripts[uid] = nil
 		elseif obj and self.hooks[obj] and self.hooks[obj][method] and obj[method] == uid then -- unhooks methods
 			obj[method] = self.hooks[obj][method]
 		end
-		
+
 		self.hooks[obj][method] = nil
 		self.hooks[obj] = next(self.hooks[obj]) and self.hooks[obj] or nil
 	else
 		registry[self][method] = nil
-		
+
 		-- if self.hooks[method] doesn't exist, then this is a SecureHook, just bail out
 		if not self.hooks[method] then return true end
-		
+
 		if self.hooks[method] and _G[method] == uid then -- unhooks functions
 			_G[method] = self.hooks[method]
 		end
-		
+
 		self.hooks[method] = nil
 	end
 	return true
@@ -478,10 +478,10 @@ function AceHook:UnhookAll()
 	for key, value in pairs(registry[self]) do
 		if type(key) == "table" then
 			for method in pairs(value) do
-				self:Unhook(key, method)
+				AceHook.Unhook(self, key, method)
 			end
 		else
-			self:Unhook(key)
+			AceHook.Unhook(self, key)
 		end
 	end
 end
@@ -501,7 +501,7 @@ function AceHook:IsHooked(obj, method)
 			return true, handlers[registry[self][obj][method]]
 		end
 	end
-	
+
 	return false, nil
 end
 

--- a/Libs/AceSerializer-3.0/AceSerializer-3.0.lua
+++ b/Libs/AceSerializer-3.0/AceSerializer-3.0.lua
@@ -1,16 +1,16 @@
 --- **AceSerializer-3.0** can serialize any variable (except functions or userdata) into a string format,
--- that can be send over the addon comm channel. AceSerializer was designed to keep all data intact, especially 
+-- that can be send over the addon comm channel. AceSerializer was designed to keep all data intact, especially
 -- very large numbers or floating point numbers, and table structures. The only caveat currently is, that multiple
 -- references to the same table will be send individually.
 --
--- **AceSerializer-3.0** can be embeded into your addon, either explicitly by calling AceSerializer:Embed(MyAddon) or by 
+-- **AceSerializer-3.0** can be embeded into your addon, either explicitly by calling AceSerializer:Embed(MyAddon) or by
 -- specifying it as an embeded library in your AceAddon. All functions will be available on your addon object
 -- and can be accessed directly, without having to explicitly call AceSerializer itself.\\
 -- It is recommended to embed AceSerializer, otherwise you'll have to specify a custom `self` on all calls you
 -- make into AceSerializer.
 -- @class file
 -- @name AceSerializer-3.0
--- @release $Id: AceSerializer-3.0.lua 1135 2015-09-19 20:39:16Z nevcairiel $
+-- @release $Id: AceSerializer-3.0.lua 1202 2019-05-15 23:11:22Z nevcairiel $
 local MAJOR,MINOR = "AceSerializer-3.0", 5
 local AceSerializer, oldminor = LibStub:NewLibrary(MAJOR, MINOR)
 
@@ -40,7 +40,7 @@ local function SerializeStringHelper(ch)	-- Used by SerializeValue for strings
 		return "\126\122"
 	elseif n<=32 then 			-- nonprint + space
 		return "\126"..strchar(n+64)
-	elseif n==94 then		-- value separator 
+	elseif n==94 then		-- value separator
 		return "\126\125"
 	elseif n==126 then		-- our own escape character
 		return "\126\124"
@@ -54,12 +54,12 @@ end
 local function SerializeValue(v, res, nres)
 	-- We use "^" as a value separator, followed by one byte for type indicator
 	local t=type(v)
-	
+
 	if t=="string" then		-- ^S = string (escaped to remove nonprints, "^"s, etc)
 		res[nres+1] = "^S"
 		res[nres+2] = gsub(v,"[%c \94\126\127]", SerializeStringHelper)
 		nres=nres+2
-	
+
 	elseif t=="number" then	-- ^N = number (just tostring()ed) or ^F (float components)
 		local str = tostring(v)
 		if tonumber(str)==v  --[[not in 4.3 or str==serNaN]] then
@@ -79,7 +79,7 @@ local function SerializeValue(v, res, nres)
 			res[nres+4] = tostring(e-53)	-- adjust exponent to counteract mantissa manipulation
 			nres=nres+4
 		end
-	
+
 	elseif t=="table" then	-- ^T...^t = table (list of key,value pairs)
 		nres=nres+1
 		res[nres] = "^T"
@@ -89,7 +89,7 @@ local function SerializeValue(v, res, nres)
 		end
 		nres=nres+1
 		res[nres] = "^t"
-	
+
 	elseif t=="boolean" then	-- ^B = true, ^b = false
 		nres=nres+1
 		if v then
@@ -97,15 +97,15 @@ local function SerializeValue(v, res, nres)
 		else
 			res[nres] = "^b"	-- false
 		end
-	
+
 	elseif t=="nil" then		-- ^Z = nil (zero, "N" was taken :P)
 		nres=nres+1
 		res[nres] = "^Z"
-	
+
 	else
 		error(MAJOR..": Cannot serialize a value of type '"..t.."'")	-- can't produce error on right level, this is wildly recursive
 	end
-	
+
 	return nres
 end
 
@@ -121,14 +121,14 @@ local serializeTbl = { "^1" }	-- "^1" = Hi, I'm data serialized by AceSerializer
 -- @return The data in its serialized form (string)
 function AceSerializer:Serialize(...)
 	local nres = 1
-	
+
 	for i=1,select("#", ...) do
 		local v = select(i, ...)
 		nres = SerializeValue(v, serializeTbl, nres)
 	end
-	
+
 	serializeTbl[nres+1] = "^^"	-- "^^" = End of serialized data
-	
+
 	return tconcat(serializeTbl, "", 1, nres+1)
 end
 
@@ -175,9 +175,9 @@ local function DeserializeValue(iter,single,ctl,data)
 		ctl,data = iter()
 	end
 
-	if not ctl then 
+	if not ctl then
 		error("Supplied data misses AceSerializer terminator ('^^')")
-	end	
+	end
 
 	if ctl=="^^" then
 		-- ignore extraneous data
@@ -185,7 +185,7 @@ local function DeserializeValue(iter,single,ctl,data)
 	end
 
 	local res
-	
+
 	if ctl=="^S" then
 		res = gsub(data, "~.", DeserializeStringHelper)
 	elseif ctl=="^N" then
@@ -218,7 +218,7 @@ local function DeserializeValue(iter,single,ctl,data)
 			ctl,data = iter()
 			if ctl=="^t" then break end	-- ignore ^t's data
 			k = DeserializeValue(iter,true,ctl,data)
-			if k==nil then 
+			if k==nil then
 				error("Invalid AceSerializer table format (no table end marker)")
 			end
 			ctl,data = iter()
@@ -231,7 +231,7 @@ local function DeserializeValue(iter,single,ctl,data)
 	else
 		error("Invalid AceSerializer control code '"..ctl.."'")
 	end
-	
+
 	if not single then
 		return res,DeserializeValue(iter)
 	else

--- a/Libs/AceTab-3.0/AceTab-3.0.lua
+++ b/Libs/AceTab-3.0/AceTab-3.0.lua
@@ -2,7 +2,7 @@
 -- Note: This library is not yet finalized.
 -- @class file
 -- @name AceTab-3.0
--- @release $Id: AceTab-3.0.lua 1148 2016-07-18 09:13:02Z nevcairiel $
+-- @release $Id: AceTab-3.0.lua 1202 2019-05-15 23:11:22Z nevcairiel $
 
 local ACETAB_MAJOR, ACETAB_MINOR = 'AceTab-3.0', 9
 local AceTab, oldminor = LibStub:NewLibrary(ACETAB_MAJOR, ACETAB_MINOR)
@@ -131,7 +131,7 @@ function AceTab:RegisterTabCompletion(descriptor, prematches, wordlist, usagefun
 	elseif type(listenframes) ~= 'table' or type(listenframes[0]) == 'userdata' and type(listenframes.IsObjectType) == 'function' then  -- single frame or framename
 		listenframes = { listenframes }
 	end
-	
+
 	-- Hook each registered listenframe and give it a matches table.
 	for _, f in pairs(listenframes) do
 		if type(f) == 'string' then
@@ -148,7 +148,7 @@ function AceTab:RegisterTabCompletion(descriptor, prematches, wordlist, usagefun
 			end
 		end
 	end
-	
+
 	-- Everything checks out; register this completion.
 	if not registry[descriptor] then
 		registry[descriptor] = { prematches = pmtable, wordlist = wordlist, usagefunc = usagefunc, listenframes = listenframes, postfunc = postfunc, pmoverwrite = pmoverwrite }
@@ -358,7 +358,7 @@ function AceTab:OnTabPressed(this)
 	firstPMLength = 0
 	hasNonFallback = false
 	for i in pairs(pmolengths) do pmolengths[i] = nil end
-	
+
 	for desc in pairs(notfallbacks) do
 		fillMatches(this, desc)
 	end
@@ -368,7 +368,7 @@ function AceTab:OnTabPressed(this)
 		end
 	end
 
-	if not firstMatch then 
+	if not firstMatch then
 		this.at3_last_precursor = "\0"
 		return true
 	end
@@ -390,7 +390,7 @@ function AceTab:OnTabPressed(this)
 		for desc, matches in pairs(this.at3matches) do
 			-- Don't print usage statements for fallback completion groups if we have 'real' completion groups with matches.
 			if hasNonFallback and fallbacks[desc] then break end
-			
+
 			-- Use the group's description as a heading for its usage statements.
 			DEFAULT_CHAT_FRAME:AddMessage(desc..":")
 

--- a/Libs/AceTimer-3.0/AceTimer-3.0.lua
+++ b/Libs/AceTimer-3.0/AceTimer-3.0.lua
@@ -15,7 +15,7 @@
 -- make into AceTimer.
 -- @class file
 -- @name AceTimer-3.0
--- @release $Id: AceTimer-3.0.lua 1170 2018-03-29 17:38:58Z funkydude $
+-- @release $Id: AceTimer-3.0.lua 1202 2019-05-15 23:11:22Z nevcairiel $
 
 local MAJOR, MINOR = "AceTimer-3.0", 17 -- Bump minor on changes
 local AceTimer, oldminor = LibStub:NewLibrary(MAJOR, MINOR)
@@ -47,7 +47,7 @@ local function new(self, loop, func, delay, ...)
 	activeTimers[timer] = timer
 
 	-- Create new timer closure to wrap the "timer" object
-	timer.callback = function() 
+	timer.callback = function()
 		if not timer.cancelled then
 			if type(timer.func) == "string" then
 				-- We manually set the unpack count to prevent issues with an arg set that contains nil and ends with nil

--- a/Libs/LibDialog-1.0/LibDialog-1.0.lua
+++ b/Libs/LibDialog-1.0/LibDialog-1.0.lua
@@ -8,8 +8,6 @@
 -----------------------------------------------------------------------
 -- Upvalued Lua API.
 -----------------------------------------------------------------------
-local _G = getfenv(0)
-
 -- Functions
 local error = _G.error
 local pairs = _G.pairs
@@ -33,7 +31,7 @@ if not lib then
     return
 end -- No upgrade needed
 
-local dialog_prototype = _G.CreateFrame("Frame", nil, _G.UIParent)
+local dialog_prototype = _G.CreateFrame("Frame", nil, _G.UIParent, _G.BackdropTemplateMixin and "BackdropTemplate")
 local dialog_meta = {
     __index = dialog_prototype
 }
@@ -117,13 +115,11 @@ local active_dialogs = lib.active_dialogs
 local active_buttons = lib.active_buttons
 local active_checkboxes = lib.active_checkboxes
 local active_editboxes = lib.active_editboxes
-local active_icons = lib.active_icons
 
 local dialog_heap = lib.dialog_heap
 local button_heap = lib.button_heap
 local checkbox_heap = lib.checkbox_heap
 local editbox_heap = lib.editbox_heap
-local icon_heap = lib.icon_heap
 
 -----------------------------------------------------------------------
 -- Helper functions.
@@ -237,7 +233,7 @@ local function _Dialog_OnShow(dialog)
         return
     end
 
-    _G.PlaySound(850) -- "igMainMenuOpen"
+    _G.PlaySound(SOUNDKIT.IG_MAINMENU_OPEN, "Master")
 
     if delegate.on_show then
         delegate.on_show(dialog, dialog.data)
@@ -245,23 +241,23 @@ local function _Dialog_OnShow(dialog)
 end
 
 local function _Dialog_OnHide(dialog)
-    local delegate = dialog.delegate
-
-    _G.PlaySound(851) -- "igMainMenuClose"
+    _G.PlaySound(SOUNDKIT.IG_MAINMENU_CLOSE, "Master")
 
     -- Required so lib:ActiveDialog() will return false if called from code which is called from the delegate's on_hide
     _RecycleWidget(dialog, active_dialogs, dialog_heap)
 
+    local delegate = dialog.delegate
     if delegate.on_hide then
         delegate.on_hide(dialog, dialog.data)
     end
+
     _ReleaseDialog(dialog)
 
     if #delegate_queue > 0 then
         local delegate
         repeat
             delegate = _ProcessQueue()
-            until not delegate
+        until not delegate
     end
 end
 

--- a/Libs/MSA-DropDownMenu-1.0/MSA-DropDownMenu-1.0.lua
+++ b/Libs/MSA-DropDownMenu-1.0/MSA-DropDownMenu-1.0.lua
@@ -1,12 +1,12 @@
 --- MSA-DropDownMenu-1.0 - DropDown menu for non-Blizzard addons
---- Copyright (c) 2016-2018, Marouan Sabbagh <mar.sabbagh@gmail.com>
+--- Copyright (c) 2016-2020, Marouan Sabbagh <mar.sabbagh@gmail.com>
 --- All Rights Reserved.
 ---
 --- https://www.curseforge.com/wow/addons/msa-dropdownmenu-10
 
-local name, version = "MSA-DropDownMenu-1.0", 7
+local name, version = "MSA-DropDownMenu-1.0", 12
 
-local lib = LibStub:NewLibrary(name, version)
+local lib, oldVersion = LibStub:NewLibrary(name, version)
 if not lib then return end
 
 -- WoW API
@@ -32,7 +32,8 @@ MSA_DROPDOWNMENU_DEFAULT_TEXT_HEIGHT = nil;
 -- List of open menus
 MSA_OPEN_DROPDOWNMENUS = {};
 
-local MSA_DropDownMenuDelegate = CreateFrame("FRAME");
+lib.delegate = lib.delegate or CreateFrame("Frame");
+local MSA_DropDownMenuDelegate = lib.delegate;
 
 ------------------------------------------------------------------------------------------------------------------------
 -- Frames
@@ -142,8 +143,6 @@ local function CreateDropDownMenuButton(name, parent)
                 GameTooltip:AddLine(parent.tooltipTitle, 1.0, 1.0, 1.0);
                 GameTooltip:AddLine(parent.tooltipText, nil, nil, nil, true);
                 GameTooltip:Show();
-            else
-                GameTooltip_AddNewbieTip(parent, parent.tooltipTitle, 1.0, 1.0, 1.0, parent.tooltipText, 1);
             end
         end
     end)
@@ -173,8 +172,6 @@ local function CreateDropDownMenuButton(name, parent)
                 GameTooltip:AddLine(self.tooltipTitle, 1.0, 1.0, 1.0);
                 GameTooltip:AddLine(self.tooltipText, nil, nil, nil, true);
                 GameTooltip:Show();
-            else
-                GameTooltip_AddNewbieTip(self, self.tooltipTitle, 1.0, 1.0, 1.0, self.tooltipText, 1);
             end
         end
     end)
@@ -207,7 +204,12 @@ local function CreateDropDownList(name, parent)
     DropDownList:SetFrameStrata("DIALOG")
     DropDownList:EnableMouse(true)
 
-    local frame1 = _G[name.."Backdrop"] or CreateFrame("Frame", name.."Backdrop", DropDownList)
+    local frame1
+    if oldVersion and oldVersion > 8 then  -- WoW 9.0 compatibility
+        frame1 = _G[name.."Backdrop"] or CreateFrame("Frame", name.."Backdrop", DropDownList, BackdropTemplateMixin and "BackdropTemplate")
+    else
+        frame1 = CreateFrame("Frame", name.."Backdrop", DropDownList, BackdropTemplateMixin and "BackdropTemplate")
+    end
     frame1:SetAllPoints()
     frame1:SetBackdrop({
         bgFile = "Interface\\DialogFrame\\UI-DialogBox-Background-Dark",
@@ -223,7 +225,12 @@ local function CreateDropDownList(name, parent)
         },
     })
 
-    local frame2 = _G[name.."MenuBackdrop"] or CreateFrame("Frame", name.."MenuBackdrop", DropDownList)
+    local frame2
+    if oldVersion and oldVersion > 8 then  -- WoW 9.0 compatibility
+        frame2 = _G[name.."MenuBackdrop"] or CreateFrame("Frame", name.."MenuBackdrop", DropDownList, BackdropTemplateMixin and "BackdropTemplate")
+    else
+        frame2 = CreateFrame("Frame", name.."MenuBackdrop", DropDownList, BackdropTemplateMixin and "BackdropTemplate")
+    end
     frame2:SetAllPoints()
     frame2:SetBackdrop({
         bgFile = "Interface\\Tooltips\\UI-Tooltip-Background",
@@ -729,9 +736,17 @@ function MSA_DropDownMenu_AddButton(info, level)
         -- Set icon
         if ( info.icon ) then
             icon:SetSize(16,16);
-            icon:SetTexture(info.icon);
+            if ( info.iconAtlas ) then
+                icon:SetAtlas(info.icon, true);
+                info.tCoordLeft = nil
+                info.tCoordRight = nil
+                info.tCoordTop = nil
+                info.tCoordBottom = nil
+            else
+                icon:SetTexture(info.icon);
+            end
             icon:ClearAllPoints();
-            icon:SetPoint("RIGHT");
+            icon:SetPoint("RIGHT", -1, 0);
 
             if ( info.tCoordLeft ) then
                 icon:SetTexCoord(info.tCoordLeft, info.tCoordRight, info.tCoordTop, info.tCoordBottom);
@@ -1432,6 +1447,26 @@ if ToggleDropDownMenu then
     end)
 end
 
+if UIDropDownMenu_HandleGlobalMouseEvent then
+    local function MSA_DropDownMenu_ContainsMouse()
+        for i = 1, MSA_DROPDOWNMENU_MAXLEVELS do
+            local dropdown = _G["MSA_DropDownList"..i];
+            if dropdown:IsShown() and dropdown:IsMouseOver() then
+                return true;
+            end
+        end
+        return false;
+    end
+
+    hooksecurefunc("UIDropDownMenu_HandleGlobalMouseEvent", function(button, event)
+        if event == "GLOBAL_MOUSE_DOWN" and (button == "LeftButton" or button == "RightButton") then
+            if not MSA_DropDownMenu_ContainsMouse() then
+                MSA_CloseDropDownMenus()
+            end
+        end
+    end)
+end
+
 function MSA_CloseDropDownMenus(level)
     if ( not level ) then
         level = 1;
@@ -1649,11 +1684,13 @@ local function LoadSkin_Tukui()
     local backdrop
     for i = 1, MSA_DROPDOWNMENU_MAXLEVELS do
         backdrop = _G["MSA_DropDownList"..i.."MenuBackdrop"]
-        backdrop:SetTemplate("Default")
+        backdrop:StripTextures()
+        backdrop:CreateBackdrop("Default")
         backdrop:CreateShadow()
         backdrop.IsSkinned = true
         backdrop = _G["MSA_DropDownList"..i.."Backdrop"]
-        backdrop:SetTemplate("Default")
+        backdrop:StripTextures()
+        backdrop:CreateBackdrop("Default")
         backdrop:CreateShadow()
         backdrop.IsSkinned = true
     end
@@ -1662,10 +1699,10 @@ end
 -- Aurora skin
 local function LoadSkin_Aurora()
     if not IsAddOnLoaded("Aurora") then return end
-    local F = _G.Aurora[1]
+    local Skin = _G.Aurora.Skin
     for i = 1, MSA_DROPDOWNMENU_MAXLEVELS do
-        F.CreateBD(_G["MSA_DropDownList"..i.."MenuBackdrop"])
-        F.CreateBD(_G["MSA_DropDownList"..i.."Backdrop"])
+        Skin.TooltipBackdropTemplate(_G["MSA_DropDownList"..i.."MenuBackdrop"])
+        Skin.TooltipBackdropTemplate(_G["MSA_DropDownList"..i.."Backdrop"])
     end
 end
 

--- a/Modules/lootFrame.lua
+++ b/Modules/lootFrame.lua
@@ -278,7 +278,7 @@ do
 		-- Expects caller to setup buttons and position.
 		Create = function(entry, parent)
 			entry.width = parent:GetWidth()
-			entry.frame = CreateFrame("Frame", "DefaultRCLootFrameEntry("..LootFrame.EntryManager.numEntries..")", parent)
+			entry.frame = CreateFrame("Frame", "DefaultRCLootFrameEntry("..LootFrame.EntryManager.numEntries..")", parent, BackdropTemplateMixin and "BackdropTemplate")
 			entry.frame:SetWidth(entry.width)
 			entry.frame:SetHeight(ENTRY_HEIGHT)
 			-- We expect entry constructors to place the frame correctly:
@@ -380,7 +380,7 @@ do
 				end
 			end)
 
-			entry.noteEditbox = CreateFrame("EditBox", nil, entry.frame, "AutoCompleteEditBoxTemplate")
+			entry.noteEditbox = CreateFrame("EditBox", nil, entry.frame, "AutoCompleteEditBoxTemplate" and BackdropTemplateMixin and "BackdropTemplate")
 			entry.noteEditbox:SetMaxLetters(64)
 			entry.noteEditbox:SetBackdrop(LootFrame.frame.title:GetBackdrop())
 			entry.noteEditbox:SetBackdropColor(LootFrame.frame.title:GetBackdropColor())

--- a/UI/Widgets/IconBordered.lua
+++ b/UI/Widgets/IconBordered.lua
@@ -5,7 +5,7 @@ local Object = {}
 
 -- varargs: texture
 function Object:New(parent, name, texture)
-   local b = addon.UI.CreateFrame("Button", name, parent)
+   local b = addon.UI.CreateFrame("Button", name, parent, BackdropTemplateMixin and "BackdropTemplate")
    b:SetSize(40,40)
    b:SetHighlightTexture("Interface\\Buttons\\ButtonHilight-Square")
    b:GetHighlightTexture():SetBlendMode("ADD")

--- a/core.lua
+++ b/core.lua
@@ -2578,7 +2578,7 @@ function RCLootCouncil:CreateFrame(name, cName, title, width, height)
 	f:MakeDraggable()
 	f:SetScript("OnMouseWheel", function(f,delta) if IsControlKeyDown() then lwin.OnMouseWheel(f,delta) end end)
 
-	local tf = CreateFrame("Frame", "RC_UI_"..cName.."_Title", f)
+	local tf = CreateFrame("Frame", "RC_UI_"..cName.."_Title", f, BackdropTemplateMixin and "BackdropTemplate")
 	--tf:SetFrameStrata("DIALOG")
 	tf:SetToplevel(true)
 	tf:SetBackdrop({
@@ -2618,7 +2618,7 @@ function RCLootCouncil:CreateFrame(name, cName, title, width, height)
 	tf.text = text
 	f.title = tf
 
-	local c = CreateFrame("Frame", "RC_UI_"..cName.."_Content", f) -- frame that contains the actual content
+	local c = CreateFrame("Frame", "RC_UI_"..cName.."_Content", f, BackdropTemplateMixin and "BackdropTemplate") -- frame that contains the actual content
 	c:SetBackdrop({
 		bgFile = AceGUIWidgetLSMlists.background[db.skins[db.currentSkin].background],
 		edgeFile = AceGUIWidgetLSMlists.border[db.skins[db.currentSkin].border],

--- a/core.lua
+++ b/core.lua
@@ -2566,7 +2566,7 @@ end
 -- @param height Height of the frame, defaults to 325.
 -- @return The frame object.
 function RCLootCouncil:CreateFrame(name, cName, title, width, height)
-	local f = CreateFrame("Frame", name, UIParent) -- LibWindow seems to work better with nil parent
+	local f = CreateFrame("Frame", name, UIParent, BackdropTemplateMixin and "BackdropTemplate") -- LibWindow seems to work better with nil parent
 	f:Hide()
 	f:SetFrameStrata("DIALOG")
 	f:SetWidth(450)


### PR DESCRIPTION
With TBC classic the WoW client now requires the BackdropMixin to be added to a CreateFrame call if the frame's parent doesn't include a Backdrop. All updates herein are designed to solve that API change.

I tried to make minimal commits to update the addon to support TBC Classic by doing this:

- Start from the current commit the submodule is set to in the RCLootCouncil_Classic Repo
- Update bundled libraries
- Update RCLootCouncil code that requires the BackdropMixin added to CreateFrame

The vast majority of the updated code here are library updates. The changes to RCLootCouncil's code are minimal.