### PR TITLE
adds serverTime and field on json export

### DIFF
--- a/Modules/History/lootHistory.lua
+++ b/Modules/History/lootHistory.lua
@@ -1647,6 +1647,7 @@ do
 				tinsert(export, string.format("\"%s\":\"%s\"", "note", QuotesEscape(d.note)))
 				tinsert(export, string.format("\"%s\":\"%s\"", "owner", tostring(d.owner or "Unknown")))
 				tinsert(export, string.format("\"%s\":\"%s\"", "itemName", ItemUtils:GetItemNameFromLink(d.lootWon)))
+				tinsert(export, string.format("\"%s\":%s", "serverTime", tostring(d.serverTime or 0)))
 
 				processedEntries = processedEntries + 1;
 

--- a/ml_core.lua
+++ b/ml_core.lua
@@ -1237,6 +1237,7 @@ function RCLootCouncilML:TrackAndLogLoot(winner, link, responseID, boss, reason,
 	history_table["id"]				= time(date("!*t")).."-"..historyCounter												-- New in v2.7+. A unique id for the history entry.
 	history_table["owner"]			= owner or self.lootTable[session] and self.lootTable[session].owner or winner		-- New in v2.9+.
 	history_table["typeCode"]			= self.lootTable[session] and self.lootTable[session].typeCode		-- New in v2.15+.
+	history_table["serverTime"]		= GetServerTime()
 
 	historyCounter = historyCounter + 1
 


### PR DESCRIPTION
The following issue details the current issue with the date and time field in the data:
https://github.com/evil-morfar/RCLootCouncil2/issues/187

This pull request doesn't solve the display issue as care would need to be taken with old data (without the actual serverTime value) and could lead to confusion.  However, as a short-term solution for applications that may either parse the RCLootCouncil.lua saved variable or use the Json export, this pull request adds a "serverTime" field to the loot data using the GetServerTime() function which is synchronized across clients and not effected by the current user's system clock or time zone.

I didn't include the EQXML export as the <enter> and <leave> timestamps are only based on the day (and not time) and dynamically swapping between the date/time epoch and the actual server epoch based on its existence may not desired.  I can add this if requested.